### PR TITLE
Discovery UI refresh, live-only data, and embedded /home

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import "./styles/tokens.css";
 import "./styles/index.scss";
 import { render } from "preact";
 

--- a/src/pages/RevoltApp.tsx
+++ b/src/pages/RevoltApp.tsx
@@ -18,6 +18,7 @@ import Developer from "./developer/Developer";
 import Discover from "./discover/Discover";
 import Friends from "./friends/Friends";
 import Home from "./home/Home";
+import HomeNew from "./home/HomeNew";
 import InviteBot from "./invite/InviteBot";
 import ChannelSettings from "./settings/ChannelSettings";
 import ServerSettings from "./settings/ServerSettings";
@@ -90,6 +91,7 @@ export default function App() {
     const path = useLocation().pathname;
     const fixedBottomNav =
         path === "/" ||
+        path === "/home" ||
         path === "/settings" ||
         path.startsWith("/friends") ||
         path.startsWith("/discover");
@@ -219,6 +221,7 @@ export default function App() {
                             <Route path="/friends" component={Friends} />
                             <Route path="/open/:id" component={Open} />
                             <Route path="/bot/:id" component={InviteBot} />
+                            <Route path="/home" component={HomeNew} />
                             <Route path="/" component={Home} />
                         </Switch>
                     </Routes>

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -55,11 +55,6 @@ export function App() {
                             <Directory />
                         </LoadSuspense>
                     </Route>
-                    <Route path="/home">
-                        <LoadSuspense>
-                            <Directory />
-                        </LoadSuspense>
-                    </Route>
                     <Route path="/login">
                         <CheckAuth>
                             <LoadSuspense>

--- a/src/pages/directory/CommunityCard.tsx
+++ b/src/pages/directory/CommunityCard.tsx
@@ -7,9 +7,30 @@ import {
     Badge, BadgeRow, Stars, StarNum,
     CommunityMeta, MetaItem, JoinBtn,
     Card, CardHead, CardLeft, CardName, CardRight, Chevron,
-    CardDivider, CardBody, SectionLabel, InfoLine,
+    CardDivider, CardBody, SectionLabel, InfoLine, MobileMetaBadgesRow,
     TableName, TableMeta,
 } from "./stylesCommunity";
+
+function getJoinState(community: Community) {
+    if (community.locked) {
+        return { text: "Join", clickable: false };
+    }
+    if (community.joinable === false) {
+        return { text: "Not Joinable", clickable: false };
+    }
+    if (!community.inviteLink) {
+        return { text: "Unavailable", clickable: false };
+    }
+    return { text: "Join →", clickable: true, href: community.inviteLink };
+}
+
+function getJoinStateRow(community: Community) {
+    const state = getJoinState(community);
+    if (state.text === "Join →") {
+        return { ...state, text: "Join" };
+    }
+    return state;
+}
 
 // ─── Star components ──────────────────────────────────────────────────────────
 
@@ -99,7 +120,7 @@ export function GuaranteeBadges({
             {guaranteeKeys.map((k) => {
                 const hintText = guaranteeTexts?.[k]?.trim() || GUARANTEE_HINTS[k];
                 return (
-                    <Badge key={k} $v="orange" data-tip={hintText}>
+                    <Badge key={k} $v="orange" data-tip={hintText} data-guarantee-chip>
                         {GUARANTEE_LABELS[k]}
                     </Badge>
                 );
@@ -163,7 +184,15 @@ export function CommunityCard({
                     <CardName>
                         {community.name}
                         {community.verified && (
-                            <span style={{ fontSize: 11, color: "#00b4d8", fontWeight: 700, marginLeft: 5 }}>✓</span>
+                            <span
+                                style={{
+                                    fontSize: "var(--font-size-caption-1)",
+                                    color: "var(--color-success)",
+                                    fontWeight: "var(--font-weight-bold)",
+                                    marginLeft: "var(--space-1)",
+                                }}>
+                                ✓
+                            </span>
                         )}
                     </CardName>
                     <CommunityMeta>
@@ -172,21 +201,45 @@ export function CommunityCard({
                         <MetaItem>{formatCount(stats.memberCount)}</MetaItem>
                         <MetaItem style={{ color: "var(--secondary-foreground)" }}>·</MetaItem>
                         <MetaItem style={{ color: "var(--success)" }}>● {formatCount(stats.onlineCount)}</MetaItem>
-                        <JoinBtn href={community.inviteLink} target="_blank" rel="noreferrer"
-                            onClick={(e) => e.stopPropagation()}>
-                            Join →
-                        </JoinBtn>
                     </CommunityMeta>
+                    {isCommerce && (
+                        <MobileMetaBadgesRow>
+                            <GuaranteeBadges guarantees={c.guarantees} guaranteeTexts={c.guaranteeTexts} />
+                            <CountryBadges warehouses={c.warehouses} />
+                        </MobileMetaBadgesRow>
+                    )}
                 </CardLeft>
                 <CardRight>
+                    {(() => {
+                        const joinState = getJoinState(community);
+                        if (joinState.clickable) {
+                            return (
+                                <JoinBtn href={joinState.href} target="_blank" rel="noreferrer"
+                                    onClick={(e) => e.stopPropagation()}>
+                                    {joinState.text}
+                                </JoinBtn>
+                            );
+                        }
+                        return (
+                            <JoinBtn as="span" style={{ opacity: 0.5, cursor: "not-allowed", filter: "grayscale(1)" }}
+                                onClick={(e) => e.stopPropagation()}>
+                                {joinState.text}
+                            </JoinBtn>
+                        );
+                    })()}
                     <div onClick={(e) => { e.stopPropagation(); onReview(); }}
                         style={{ cursor: "pointer" }} title="Open reviews">
                         <StarRating rating={community.rating} />
-                        <div style={{ fontSize: 10, color: "var(--tertiary-foreground)", textAlign: "right", marginTop: 1 }}>
+                        <div
+                            style={{
+                                fontSize: "var(--font-size-caption-1)",
+                                color: "var(--tertiary-foreground)",
+                                textAlign: "right",
+                                marginTop: "var(--space-1)",
+                            }}>
                             {reviewCount} review{reviewCount !== 1 ? "s" : ""}
                         </div>
                     </div>
-                    {isCommerce && <CountryBadges warehouses={c.warehouses} />}
                     <Chevron $open={open}>▾</Chevron>
                 </CardRight>
             </CardHead>
@@ -214,7 +267,12 @@ export function CommunityCard({
                             <InfoLine>
                                 <Badge $v="green">Free Shipping</Badge>
                                 {c.freeShippingThreshold && (
-                                    <span style={{ fontSize: 11, marginLeft: 6, color: "var(--tertiary-foreground)" }}>
+                                    <span
+                                        style={{
+                                            fontSize: "var(--font-size-caption-1)",
+                                            marginLeft: "var(--space-2)",
+                                            color: "var(--tertiary-foreground)",
+                                        }}>
                                         over {c.freeShippingThreshold}
                                     </span>
                                 )}
@@ -248,7 +306,12 @@ export function CommunityRow({
         <tr>
             <td onClick={onReview} style={{ cursor: "pointer", whiteSpace: "nowrap" }} title="Open reviews">
                 <StarRating rating={community.rating} />
-                <div style={{ fontSize: 10, color: "var(--tertiary-foreground)", marginTop: 3 }}>
+                <div
+                    style={{
+                        fontSize: "var(--font-size-caption-1)",
+                        color: "var(--tertiary-foreground)",
+                        marginTop: "var(--space-1)",
+                    }}>
                     {reviewCount} review{reviewCount !== 1 ? "s" : ""}
                 </div>
             </td>
@@ -263,10 +326,6 @@ export function CommunityRow({
                     <span>{formatCount(stats.memberCount)} members</span>
                     <span className="sep">·</span>
                     <span className="online">● {formatCount(stats.onlineCount)}</span>
-                    <JoinBtn href={community.inviteLink} target="_blank" rel="noreferrer"
-                        style={{ fontSize: 10, padding: "2px 9px", marginLeft: 4 }}>
-                        Join
-                    </JoinBtn>
                 </TableMeta>
             </td>
             {isCommerce ? (
@@ -274,20 +333,46 @@ export function CommunityRow({
                     <td><PaymentBadges payment={c.payment} /></td>
                     <td><CountryBadges warehouses={c.warehouses} /></td>
                     <td><ProductBadges products={c.products} /></td>
-                    <td><GuaranteeBadges guarantees={c.guarantees} guaranteeTexts={c.guaranteeTexts} /></td>
+                    <td style={{ minWidth: 160 }}><GuaranteeBadges guarantees={c.guarantees} guaranteeTexts={c.guaranteeTexts} /></td>
                     {isReseller && <td>{c.orderTypes ? <OrderBadges orderTypes={c.orderTypes} /> : <span style={{ color: "var(--tertiary-foreground)" }}>—</span>}</td>}
                     <td>
                         {c.freeShipping
                             ? <Badge $v="green">✓ {c.freeShippingThreshold || "Yes"}</Badge>
                             : <span style={{ color: "var(--tertiary-foreground)" }}>—</span>}
                     </td>
-                    <td style={{ whiteSpace: "nowrap", color: "var(--secondary-foreground)" }}>{c.shippingTime}</td>
+                    <td style={{ whiteSpace: "nowrap", color: "var(--color-text-primary)" }}>{c.shippingTime}</td>
                 </>
             ) : (
-                <td colSpan={isReseller ? 7 : 6} style={{ color: "var(--tertiary-foreground)", fontSize: 12, fontStyle: "italic" }}>
+                <td
+                    colSpan={isReseller ? 7 : 6}
+                    style={{
+                        color: "var(--tertiary-foreground)",
+                        fontSize: "var(--font-size-footnote)",
+                        fontStyle: "italic",
+                    }}>
                     General community
                 </td>
             )}
+            <td>
+                {(() => {
+                    const joinState = getJoinStateRow(community);
+                    if (joinState.clickable) {
+                        return (
+                            <JoinBtn href={joinState.href} target="_blank" rel="noreferrer"
+                                onClick={(e) => e.stopPropagation()}>
+                                {joinState.text}
+                            </JoinBtn>
+                        );
+                    }
+                    return (
+                        <JoinBtn as="span"
+                            style={{ opacity: 0.5, cursor: "not-allowed", filter: "grayscale(1)" }}
+                            onClick={(e) => e.stopPropagation()}>
+                            {joinState.text}
+                        </JoinBtn>
+                    );
+                })()}
+            </td>
         </tr>
     );
 }

--- a/src/pages/directory/SubmitModal.tsx
+++ b/src/pages/directory/SubmitModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 import type { SubmitForm, Payment, Warehouses, Products, Guarantees, GuaranteeTexts, OrderTypes } from "./types";
 import { PAYMENT_LABELS, WAREHOUSE_LABELS, PRODUCT_LABELS, GUARANTEE_LABELS, GUARANTEE_TEXT_DEFAULTS, ORDER_LABELS } from "./types";
 import { defPay, defWh, defPr, defGu, defGuText, defOr, toggle } from "./dataUtils";
@@ -17,17 +17,71 @@ export function SubmitModal({
     const [form, setForm] = useState<SubmitForm>({
         type: initialType, name: "", inviteLink: "", serverId: "",
         payment: { ...defPay }, warehouses: { ...defWh },
-        products: { ...defPr }, guarantees: { ...defGu }, guaranteeTexts: { ...defGuText }, orderTypes: { ...defOr }, notes: "",
+        products: { ...defPr }, guarantees: { ...defGu }, guaranteeTexts: { ...defGuText }, orderTypes: { ...defOr },
+        proofs: [], externalLinks: "", coas: "", shortDescription: "", notes: "",
     });
     const [submitted, setSubmitted] = useState(false);
     const [error, setError] = useState("");
+    const [customWarehouse, setCustomWarehouse] = useState("");
+    const [showCustomWarehouseInput, setShowCustomWarehouseInput] = useState(false);
+    const [availableCustomWarehouses, setAvailableCustomWarehouses] = useState<string[]>([]);
+    const [showProofInfo, setShowProofInfo] = useState(false);
+    const [isMobileLayout, setIsMobileLayout] = useState(() =>
+        typeof window !== "undefined"
+            ? window.matchMedia("(max-width: 767px)").matches
+            : false,
+    );
+
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+
+        const mediaQuery = window.matchMedia("(max-width: 767px)");
+        const update = () => setIsMobileLayout(mediaQuery.matches);
+
+        update();
+        mediaQuery.addEventListener("change", update);
+
+        return () => mediaQuery.removeEventListener("change", update);
+    }, []);
 
     const isCommerce = form.type === "vendor" || form.type === "reseller";
+
+    function addCustomWarehouse() {
+        const val = customWarehouse.trim().toUpperCase();
+        if (!val) return;
+
+        setAvailableCustomWarehouses((prev) => prev.includes(val) ? prev : [...prev, val]);
+
+        const current: string[] = form.warehouses.custom ?? [];
+        if (!current.includes(val)) {
+            setForm((f) => ({ ...f, warehouses: { ...f.warehouses, custom: [...current, val] } }));
+        }
+
+        setCustomWarehouse("");
+        setShowCustomWarehouseInput(false);
+    }
 
     function handleSubmit(e: Event) {
         e.preventDefault();
         if (!form.name.trim()) { setError("Name is required."); return; }
         if (!form.inviteLink.trim()) { setError("PepChat invite link is required."); return; }
+
+        if (isCommerce) {
+            if (form.proofs.length === 0) {
+                setError("Proof upload is required.");
+                return;
+            }
+            if (!form.shortDescription.trim()) {
+                setError("Server description is required.");
+                return;
+            }
+            const words = form.shortDescription.trim().split(/\s+/).length;
+            if (words > 10) {
+                setError(`Server description must be 10 words or less (currently ${words}).`);
+                return;
+            }
+        }
+
         onSubmit(form);
         setSubmitted(true);
     }
@@ -93,18 +147,102 @@ export function SubmitModal({
                                             ))}
                                         </CheckboxGrid>
                                     </FormGroup>
+
                                     <FormGroup>
-                                        <label>Countries Served</label>
+                                        <label>Warehouse Location(s)</label>
                                         <CheckboxGrid>
+                                            {/* Preset chips */}
                                             {(Object.keys(WAREHOUSE_LABELS) as (keyof Warehouses)[]).map((k) => (
-                                                <CheckLabel key={k} $checked={form.warehouses[k]}>
-                                                    <input type="checkbox" checked={form.warehouses[k]}
+                                                <CheckLabel key={k} $checked={!!form.warehouses[k]}>
+                                                    <input type="checkbox" checked={!!form.warehouses[k]}
                                                         onChange={() => setForm((f) => ({ ...f, warehouses: toggle(f.warehouses, k) }))} />
                                                     {WAREHOUSE_LABELS[k]}
                                                 </CheckLabel>
                                             ))}
+                                            {/* Added custom chips */}
+                                            {availableCustomWarehouses.map((val) => {
+                                                const isChecked = (form.warehouses.custom ?? []).includes(val);
+                                                return (
+                                                    <CheckLabel key={val} $checked={isChecked}>
+                                                        <input type="checkbox" checked={isChecked}
+                                                            onChange={() => setForm((f) => {
+                                                                const current = f.warehouses.custom ?? [];
+                                                                const next = current.includes(val)
+                                                                    ? current.filter(v => v !== val)
+                                                                    : [...current, val];
+                                                                return { ...f, warehouses: { ...f.warehouses, custom: next } };
+                                                            })} />
+                                                        {val}
+                                                    </CheckLabel>
+                                                );
+                                            })}
+                                            {/* Inline "Add Custom" toggle */}
+                                            {!showCustomWarehouseInput ? (
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setShowCustomWarehouseInput(true)}
+                                                    style={{
+                                                        display: "inline-flex", alignItems: "center", gap: 4,
+                                                        padding: "4px 10px", borderRadius: 6,
+                                                        border: "1px dashed var(--dir-accent)",
+                                                        background: "transparent",
+                                                        color: "var(--dir-accent)",
+                                                        fontSize: 12, fontWeight: 600,
+                                                        cursor: "pointer", transition: "all 0.12s",
+                                                        letterSpacing: "0.02em", whiteSpace: "nowrap",
+                                                        height: "28px", boxSizing: "border-box",
+                                                    }}
+                                                >+ Add Custom</button>
+                                            ) : (
+                                                <div style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+                                                    <input
+                                                        // eslint-disable-next-line jsx-a11y/no-autofocus
+                                                        autoFocus
+                                                        type="text"
+                                                        value={customWarehouse}
+                                                        onInput={(e) => setCustomWarehouse((e.target as HTMLInputElement).value.toUpperCase())}
+                                                        onKeyDown={(e) => {
+                                                            if (e.key === "Enter") { e.preventDefault(); addCustomWarehouse(); }
+                                                            if (e.key === "Escape") { setShowCustomWarehouseInput(false); setCustomWarehouse(""); }
+                                                        }}
+                                                        placeholder="e.g. BR"
+                                                        maxLength={10}
+                                                        style={{
+                                                            width: 68, padding: "0 8px",
+                                                            borderRadius: 6,
+                                                            border: "1px solid var(--dir-accent)",
+                                                            background: "var(--color-surface-alt)",
+                                                            color: "var(--color-text-primary)",
+                                                            fontSize: 12, fontFamily: "inherit",
+                                                            outline: "none", boxSizing: "border-box",
+                                                            height: "28px",
+                                                            margin: 0,
+                                                        }}
+                                                    />
+                                                    <button type="button" onClick={addCustomWarehouse}
+                                                        style={{
+                                                            padding: "0 8px", borderRadius: 6,
+                                                            border: "none", background: "var(--dir-accent)",
+                                                            color: "white", fontSize: 12, fontWeight: 700,
+                                                            cursor: "pointer", height: "28px", boxSizing: "border-box",
+                                                            display: "flex", alignItems: "center", justifyContent: "center",
+                                                        }}>✓</button>
+                                                    <button type="button"
+                                                        onClick={() => { setShowCustomWarehouseInput(false); setCustomWarehouse(""); }}
+                                                        style={{
+                                                            padding: "0 8px", borderRadius: 6,
+                                                            border: "1px solid var(--block)",
+                                                            background: "transparent",
+                                                            color: "var(--secondary-foreground)",
+                                                            fontSize: 12, cursor: "pointer",
+                                                            height: "28px", boxSizing: "border-box",
+                                                            display: "flex", alignItems: "center", justifyContent: "center",
+                                                        }}>✕</button>
+                                                </div>
+                                            )}
                                         </CheckboxGrid>
                                     </FormGroup>
+
                                     <FormGroup>
                                         <label>Products</label>
                                         <CheckboxGrid>
@@ -144,6 +282,160 @@ export function SubmitModal({
                                             ))}
                                         </div>
                                     </FormGroup>
+
+                                    <FormGroup>
+                                        <div style={{
+                                            display: "flex",
+                                            alignItems: "center",
+                                            gap: 8,
+                                            marginBottom: 6,
+                                            position: "relative",
+                                            width: "100%",
+                                        }}>
+                                            <label style={{ margin: 0 }}>PROOF UPLOAD (REQUIRED)</label>
+                                            <div
+                                                style={{
+                                                    position: isMobileLayout ? "static" : "relative",
+                                                    display: "inline-flex",
+                                                }}
+                                                onMouseEnter={() => setShowProofInfo(true)}
+                                                onMouseLeave={() => setShowProofInfo(false)}
+                                            >
+                                                <button
+                                                    type="button"
+                                                    style={{
+                                                        display: "flex", alignItems: "center", justifyContent: "center",
+                                                        width: 18, height: 18, borderRadius: "50%",
+                                                        background: "var(--dir-accent)",
+                                                        color: "white",
+                                                        border: "none",
+                                                        fontSize: 11, fontWeight: "bold",
+                                                        cursor: "pointer", transition: "all 0.12s",
+                                                        filter: showProofInfo ? "brightness(1.15)" : "none",
+                                                        padding: 0
+                                                    }}
+                                                    title=""
+                                                >
+                                                    i
+                                                </button>
+                                                {showProofInfo && (
+                                                    <div style={{
+                                                        position: "absolute",
+                                                        top: "calc(100% + 8px)",
+                                                        left: isMobileLayout ? "50%" : "0",
+                                                        right: "auto",
+                                                        transform: isMobileLayout ? "translateX(-50%)" : "none",
+                                                        width: isMobileLayout
+                                                            ? "min(280px, calc(100% - 12px))"
+                                                            : "280px",
+                                                        maxWidth: isMobileLayout
+                                                            ? "calc(100% - 12px)"
+                                                            : "280px",
+                                                        zIndex: 100,
+                                                        fontSize: 12,
+                                                        color: "var(--color-text-primary)",
+                                                        background: "var(--color-surface-alt)",
+                                                        boxShadow: "var(--shadow-lg)",
+                                                        border: "1px solid var(--dir-border-card)",
+                                                        borderRadius: 6,
+                                                        padding: "12px 14px",
+                                                        pointerEvents: "none",
+                                                        whiteSpace: "normal",
+                                                        overflowWrap: "anywhere"
+                                                    }}>
+                                                        <div style={{ fontWeight: 600, marginBottom: 6 }}>
+                                                            Please upload photos or videos showing:
+                                                        </div>
+                                                        <ul style={{ margin: 0, paddingLeft: 20, display: "flex", flexDirection: "column", gap: 4, color: "var(--color-text-secondary)", fontWeight: 600 }}>
+                                                            <li>A facility or large inventory</li>
+                                                            <li>A handwritten sign: <strong>"Company name + PepChat + today's date"</strong></li>
+                                                        </ul>
+                                                    </div>
+                                                )}
+                                            </div>
+                                        </div>
+                                        <div style={{ position: "relative", display: "inline-block" }}>
+                                            <input
+                                                type="file"
+                                                multiple
+                                                accept="image/*,video/*"
+                                                onChange={(e) => {
+                                                    const files = Array.from((e.target as HTMLInputElement).files || []);
+                                                    setForm(f => ({ ...f, proofs: [...f.proofs, ...files] }));
+                                                    // clear input to allow same file selection again if deleted
+                                                    (e.target as HTMLInputElement).value = "";
+                                                }}
+                                                style={{
+                                                    position: "absolute",
+                                                    left: 0, top: 0, width: "100%", height: "100%",
+                                                    opacity: 0, cursor: "pointer"
+                                                }}
+                                                title="Upload Images / Video"
+                                            />
+                                            <button type="button" style={{
+                                                padding: "4px 10px", borderRadius: 6,
+                                                border: "1px solid var(--block)",
+                                                background: "var(--color-surface-alt)",
+                                                color: "var(--color-text-primary)",
+                                                fontSize: 13,
+                                                cursor: "pointer",
+                                                display: "flex", alignItems: "center", gap: 4
+                                            }}>+ Upload Images / Video</button>
+                                        </div>
+                                        {form.proofs.length > 0 && (
+                                            <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 8 }}>
+                                                {form.proofs.map((file, i) => (
+                                                    <div key={i} style={{
+                                                        fontSize: 12, padding: "4px 8px",
+                                                        background: "var(--block)", borderRadius: 4,
+                                                        display: "flex", alignItems: "center", gap: 6
+                                                    }}>
+                                                        <span>{file.name}</span>
+                                                        <button type="button" onClick={() => {
+                                                            setForm(f => ({
+                                                                ...f,
+                                                                proofs: f.proofs.filter((_, idx) => idx !== i)
+                                                            }));
+                                                        }} style={{
+                                                            border: "none", background: "none",
+                                                            color: "var(--secondary-foreground)", cursor: "pointer",
+                                                            fontSize: 12, padding: 0,
+                                                            display: "flex", alignItems: "center", justifyContent: "center"
+                                                        }}>✕</button>
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        )}
+                                    </FormGroup>
+
+                                    <FormGroup>
+                                        <label>EXTERNAL LINKS</label>
+                                        <input type="text" value={form.externalLinks}
+                                            onInput={(e) => setForm((f) => ({ ...f, externalLinks: (e.target as HTMLInputElement).value }))}
+                                            placeholder="Website URL" />
+                                        <div style={{ fontSize: 12, color: "var(--secondary-foreground)", marginTop: 4 }}>
+                                            Website, social media, Made-in-China, Alibaba, or other public profiles
+                                        </div>
+                                    </FormGroup>
+
+                                    <FormGroup>
+                                        <label>COA/S</label>
+                                        <input type="text" value={form.coas}
+                                            onInput={(e) => setForm((f) => ({ ...f, coas: (e.target as HTMLInputElement).value }))}
+                                            placeholder="Janoshik, Peptidetest, Vanguard, Chromate" />
+                                        <div style={{ fontSize: 12, color: "var(--secondary-foreground)", marginTop: 4 }}>
+                                            Add links to Certificates of Analysis
+                                        </div>
+                                    </FormGroup>
+
+                                    <FormGroup>
+                                        <label>SERVER DESCRIPTION (REQUIRED)</label>
+                                        <textarea value={form.shortDescription}
+                                            onInput={(e) => setForm((f) => ({ ...f, shortDescription: (e.target as HTMLTextAreaElement).value }))}
+                                            placeholder="Brief description, up to 10 words"
+                                            rows={2} />
+                                    </FormGroup>
+
                                     {form.type === "reseller" && (
                                         <FormGroup>
                                             <label>Order Types</label>
@@ -162,10 +454,11 @@ export function SubmitModal({
                             )}
 
                             <FormGroup>
-                                <label>Notes (optional)</label>
+                                <label>NOTES (OPTIONAL)</label>
                                 <textarea value={form.notes}
                                     onInput={(e) => setForm((f) => ({ ...f, notes: (e.target as HTMLTextAreaElement).value }))}
-                                    placeholder="Describe your community, focus area, etc." />
+                                    placeholder="Describe your community, focus area, etc."
+                                    rows={3} />
                             </FormGroup>
                             {error && <ErrorMsg>{error}</ErrorMsg>}
                             <PrimaryBtn type="submit">Submit for Review</PrimaryBtn>

--- a/src/pages/directory/dataUtils.ts
+++ b/src/pages/directory/dataUtils.ts
@@ -16,54 +16,8 @@ import type {
 } from "./types";
 import { GUARANTEE_TEXT_DEFAULTS } from "./types";
 
-// ─── CSV Parser ───────────────────────────────────────────────────────────────
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
-export function parseCSV(text: string): Record<string, string>[] {
-    const lines = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
-    if (lines.length < 2) return [];
-    const headers = splitCSVRow(lines[0]);
-    const rows: Record<string, string>[] = [];
-    for (let i = 1; i < lines.length; i++) {
-        const line = lines[i].trim();
-        if (!line) continue;
-        const values = splitCSVRow(line);
-        const row: Record<string, string> = {};
-        headers.forEach((h, idx) => {
-            row[h.trim()] = values[idx]?.trim() ?? "";
-        });
-        rows.push(row);
-    }
-    return rows;
-}
-
-function splitCSVRow(line: string): string[] {
-    const result: string[] = [];
-    let cur = "";
-    let inQuote = false;
-    for (let i = 0; i < line.length; i++) {
-        const ch = line[i];
-        if (ch === '"') {
-            if (inQuote && line[i + 1] === '"') {
-                cur += '"';
-                i++;
-            } else inQuote = !inQuote;
-        } else if (ch === "," && !inQuote) {
-            result.push(cur);
-            cur = "";
-        } else {
-            cur += ch;
-        }
-    }
-    result.push(cur);
-    return result;
-}
-
-function toBool(v: string): boolean {
-    return v === "TRUE" || v === "true" || v === "1";
-}
-function toNum(v: string): number {
-    return parseFloat(v) || 0;
-}
 function toText(v: string | undefined, fallback: string): string {
     const trimmed = (v ?? "").trim();
     return trimmed || fallback;
@@ -79,99 +33,6 @@ function mapGuaranteeTexts(
     };
 }
 
-export function rowToCommunity(r: Record<string, string>): Community | null {
-    const type = r["type"] as "vendor" | "reseller" | "other";
-    if (!type || !r["id"]) return null;
-    const base: CommunityBase = {
-        id: r["id"],
-        type,
-        name: r["name"] || "",
-        logo: r["logo"] || null,
-        inviteLink: r["inviteLink"] || "",
-        serverId: r["serverId"] || null,
-        ageDays: toNum(r["ageDays"]),
-        verified: toBool(r["verified"]),
-        memberCount: toNum(r["memberCount"]),
-        onlineCount: toNum(r["onlineCount"]),
-        rating: toNum(r["rating"]),
-        notes: r["notes"] || "",
-    };
-    if (type === "other") return base as OtherCommunity;
-    const commerce = {
-        ...base,
-        payment: {
-            cc: toBool(r["cc"]),
-            btc: toBool(r["btc"]),
-            pp: toBool(r["pp"]),
-            zelle: toBool(r["zelle"]),
-            venmo: toBool(r["venmo"]),
-            bt: toBool(r["bt"]),
-            chk: toBool(r["chk"]),
-        },
-        warehouses: {
-            us: toBool(r["us"]),
-            eu: toBool(r["eu"]),
-            aus: toBool(r["aus"]),
-        },
-        products: {
-            pep: toBool(r["pep"]),
-            oil: toBool(r["oil"]),
-            tabs: toBool(r["tabs"]),
-            raw: toBool(r["raw"]),
-            amn: toBool(r["amn"]),
-            sup: toBool(r["sup"]),
-            aas: toBool(r["aas"]),
-        },
-        guarantees: {
-            purity: toBool(r["guaranteePurity"]),
-            volume: toBool(r["guaranteeVolume"]),
-            reship: toBool(r["guaranteeReship"]),
-        },
-        guaranteeTexts: {
-            purity: toText(
-                r["guaranteePurityText"],
-                GUARANTEE_TEXT_DEFAULTS.purity,
-            ),
-            volume: toText(
-                r["guaranteeVolumeText"],
-                GUARANTEE_TEXT_DEFAULTS.volume,
-            ),
-            reship: toText(
-                r["guaranteeReshipText"],
-                GUARANTEE_TEXT_DEFAULTS.reship,
-            ),
-        },
-        shippingTime: r["shippingTime"] || "",
-        freeShipping: toBool(r["freeShipping"]),
-        freeShippingThreshold: r["freeShippingThreshold"] || "",
-    };
-    if (type === "reseller") {
-        return {
-            ...commerce,
-            type: "reseller",
-            orderTypes: {
-                single: toBool(r["orderSingle"]),
-                halfkit: toBool(r["orderHalfkit"]),
-                fullkit: toBool(r["orderFullkit"]),
-            },
-        } as ResellerCommunity;
-    }
-    return { ...commerce, type: "vendor", orderTypes: null } as VendorCommunity;
-}
-
-export function rowToReview(r: Record<string, string>): Review | null {
-    if (!r["id"] || !r["vendorId"]) return null;
-    return {
-        id: r["id"],
-        vendorId: r["vendorId"],
-        vendorType: r["vendorType"] || "vendor",
-        reviewerName: r["reviewerName"] || "Anonymous",
-        rating: toNum(r["rating"]) || 5,
-        text: r["text"] || "",
-        date: r["date"] || "",
-    };
-}
-
 // ─── Default map values ───────────────────────────────────────────────────────
 
 export const defPay: Payment = {
@@ -184,7 +45,13 @@ export const defPay: Payment = {
     chk: false,
     custom: [],
 };
-export const defWh: Warehouses = { us: false, eu: false, aus: false, cn: false, custom: [] };
+export const defWh: Warehouses = {
+    us: false,
+    eu: false,
+    aus: false,
+    cn: false,
+    custom: [],
+};
 export const defPr: Products = {
     pep: false,
     oil: false,
@@ -194,7 +61,7 @@ export const defPr: Products = {
     sup: false,
     aas: false,
     custom: [],
-};;
+};
 export const defGu: Guarantees = {
     purity: false,
     volume: false,
@@ -216,7 +83,7 @@ export function apiToCommunity(c: any): Community {
         type: c.type,
         name: c.name || "",
         logo: c.logo || null,
-        inviteLink: c.inviteLink || "",
+        inviteLink: c.inviteLink || null,
         serverId: c.serverId || null,
         ageDays: c.ageDays || 0,
         verified: c.verified || false,
@@ -224,6 +91,9 @@ export function apiToCommunity(c: any): Community {
         onlineCount: c.onlineCount || 0,
         rating: c.rating || 0,
         notes: c.notes || "",
+        sortorder: c.sortorder || 0,
+        locked: c.locked ?? false,
+        joinable: c.joinable ?? true,
     };
     if (c.type === "other") return base as OtherCommunity;
 

--- a/src/pages/directory/stylesCommunity.ts
+++ b/src/pages/directory/stylesCommunity.ts
@@ -1,86 +1,63 @@
 import styled, { css } from "styled-components/macro";
 
-import { ac, cy, gr, or, fadeUp } from "./stylesLayout";
+import { fadeUp } from "./stylesLayout";
 
 // ─── Badges ───────────────────────────────────────────────────────────────────
 
 type BV = "accent" | "green" | "purple" | "orange" | "dim" | "teal" | "red";
 
+const chipTone = css`
+    background: var(--color-surface);
+    color: var(--color-text-primary) !important;
+    border-color: var(--color-border);
+`;
+
 const bv: Record<BV, ReturnType<typeof css>> = {
-    accent: css`
-        background: ${ac(0.12)};
-        color: var(--dir-accent);
-        border-color: ${ac(0.28)};
-    `,
-    green: css`
-        background: ${gr(0.1)};
-        color: var(--success);
-        border-color: ${gr(0.25)};
-    `,
-    purple: css`
-        background: ${cy(0.1)};
-        color: #00b4d8;
-        border-color: ${cy(0.25)};
-    `,
-    orange: css`
-        background: ${or(0.1)};
-        color: var(--warning);
-        border-color: ${or(0.25)};
-    `,
-    dim: css`
-        background: var(--dir-overlay-sm);
-        color: var(--tertiary-foreground);
-        border-color: var(--block);
-    `,
-    teal: css`
-        background: rgba(0, 180, 216, 0.15);
-        color: #00b4d8;
-        border-color: rgba(0, 180, 216, 0.4);
-    `,
-    red: css`
-        background: rgba(239, 68, 68, 0.1);
-        color: #ef4444;
-        border-color: rgba(239, 68, 68, 0.3);
-    `,
+    accent: chipTone,
+    green: chipTone,
+    purple: chipTone,
+    orange: chipTone,
+    dim: chipTone,
+    teal: chipTone,
+    red: chipTone,
 };
 
 export const Badge = styled.span<{ $v?: BV }>`
     display: inline-block;
-    padding: 2px 7px;
-    border-radius: 4px;
-    font-size: 11px;
-    font-weight: 700;
-    letter-spacing: 0.02em;
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--radius-sm);
+    font-size: var(--font-size-caption-1);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: 0;
     border: 1px solid transparent;
     white-space: nowrap;
     position: relative;
-    transition: transform 0.13s ease, filter 0.13s ease;
+    transition: transform 0.13s ease;
     ${(p) => bv[p.$v ?? "dim"]}
 
-    &[data-tip]:hover {
+    &:hover {
         transform: translateY(-1px);
-        filter: brightness(1.08);
     }
 
     &[data-tip]::after {
         content: attr(data-tip);
         position: absolute;
         left: 50%;
-        bottom: calc(100% + 9px);
-        transform: translate(-50%, 4px);
+        bottom: calc(100% + var(--space-2));
+        transform: translate(-50%, var(--space-1));
         min-width: 220px;
         max-width: min(300px, 70vw);
         width: max-content;
-        padding: 8px 10px;
-        border-radius: 8px;
+        padding: var(--space-2) var(--space-3);
+        border-radius: var(--radius-md);
         border: 1px solid var(--dir-border-table);
         background: var(--dir-surface-card);
         color: var(--foreground);
-        box-shadow: 0 8px 22px ${ac(0.18)};
-        font-size: 11px;
-        font-weight: 600;
+        box-shadow: none;
+        font-size: var(--font-size-caption-1);
+        font-weight: var(--font-weight-semibold);
         letter-spacing: 0;
-        line-height: 1.35;
+        line-height: var(--line-height-normal);
         white-space: pre-line;
         pointer-events: none;
         opacity: 0;
@@ -93,9 +70,9 @@ export const Badge = styled.span<{ $v?: BV }>`
         content: "";
         position: absolute;
         left: 50%;
-        bottom: calc(100% + 2px);
+        bottom: calc(100% + var(--space-1));
         transform: translateX(-50%);
-        border: 6px solid transparent;
+        border: var(--space-2) solid transparent;
         border-top-color: var(--dir-border-table);
         pointer-events: none;
         opacity: 0;
@@ -113,11 +90,53 @@ export const Badge = styled.span<{ $v?: BV }>`
     &[data-tip]:hover::after {
         transform: translate(-50%, 0);
     }
+
+    &[data-guarantee-chip][data-tip]::after {
+        background: #1C1720;
+        color: var(--color-text-primary);
+        border-color: #49454c;
+    }
+
+    &[data-guarantee-chip][data-tip]::before {
+        border-top-color: #49454c;
+    }
+
+    @media (max-width: 767px) {
+        &[data-guarantee-chip]:hover {
+            transform: none;
+        }
+
+        &[data-guarantee-chip][data-tip]:hover::after,
+        &[data-guarantee-chip][data-tip]:hover::before {
+            opacity: 0;
+            visibility: hidden;
+        }
+
+        &[data-tip]::after {
+            left: 0;
+            right: auto;
+            bottom: calc(100% + var(--space-2));
+            transform: translate(0, var(--space-1));
+            min-width: 0;
+            width: max-content;
+            max-width: min(280px, calc(100vw - 42px));
+            white-space: normal;
+        }
+
+        &[data-tip]:hover::after {
+            transform: translate(0, 0);
+        }
+
+        &[data-tip]::before {
+            left: var(--space-4);
+            transform: translateX(0);
+        }
+    }
 `;
 
 export const BadgeRow = styled.div`
     display: flex;
-    gap: 4px;
+    gap: var(--space-1);
     flex-wrap: wrap;
 `;
 
@@ -125,14 +144,15 @@ export const BadgeRow = styled.div`
 
 export const Stars = styled.span`
     color: var(--warning);
-    font-size: 12px;
-    letter-spacing: 0.5px;
+    font-size: var(--font-size-footnote);
+    letter-spacing: 0;
 `;
+
 export const StarNum = styled.span`
-    font-size: 12px;
-    font-weight: 700;
+    font-size: var(--font-size-footnote);
+    font-weight: var(--font-weight-bold);
     color: var(--warning);
-    margin-left: 3px;
+    margin-left: var(--space-1);
 `;
 
 // ─── Community Card header row ────────────────────────────────────────────────
@@ -140,17 +160,17 @@ export const StarNum = styled.span`
 export const CommunityMeta = styled.div`
     display: flex;
     align-items: center;
-    gap: 4px;
+    gap: var(--space-1);
     flex-wrap: wrap;
-    margin-top: 5px;
-    font-size: 11.5px;
+    margin-top: var(--space-1);
+    font-size: var(--font-size-caption-1);
     color: var(--secondary-foreground);
 `;
 
 export const MetaItem = styled.span`
     display: inline-flex;
     align-items: center;
-    gap: 3px;
+    gap: var(--space-1);
     white-space: nowrap;
 `;
 
@@ -158,20 +178,23 @@ export const JoinBtn = styled.a`
     && {
         display: inline-flex;
         align-items: center;
-        gap: 4px;
-        padding: 3px 10px;
-        border-radius: 5px;
-        font-size: 11px;
-        font-weight: 700;
-        background: var(--dir-accent);
-        color: #fff !important;
+        gap: var(--space-1);
+        padding: var(--space-2) var(--space-4);
+        border-radius: var(--radius-md);
+        font-size: var(--font-size-subhead);
+        font-weight: var(--font-weight-bold);
+        background: #662d91;
+        color: var(--color-text-primary) !important;
         text-decoration: none !important;
-        border: none;
-        transition: filter 0.13s;
+        border: 1px solid #662d91;
+        transition: background-color 0.13s, transform 0.13s;
         white-space: nowrap;
         cursor: pointer;
+        box-shadow: var(--shadow-sm);
+
         &:hover {
-            filter: brightness(1.15);
+            background: #5b277f;
+            transform: translateY(-1px);
         }
     }
 `;
@@ -181,7 +204,7 @@ export const JoinBtn = styled.a`
 export const CardGrid = styled.div`
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(min(100%, 300px), 1fr));
-    gap: 12px;
+    gap: var(--space-3);
 
     @media (min-width: 481px) and (max-width: 767px) {
         grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -189,35 +212,33 @@ export const CardGrid = styled.div`
 
     @media (max-width: 480px) {
         grid-template-columns: 1fr;
-        gap: 10px;
+        gap: var(--space-2);
     }
 `;
 
 export const Card = styled.div`
-    background: var(--dir-surface-card);
-    border: 1px solid var(--dir-border-card);
-    border-radius: 10px;
+    background: var(--dir-surface-table);
+    border: 1px solid var(--dir-border-table);
+    border-radius: var(--radius-lg);
     overflow: hidden;
-    transition: border-color 0.2s, transform 0.2s, box-shadow 0.2s;
-    box-shadow: 0 2px 8px ${ac(0.06)};
+    transition: background-color 0.2s, border-color 0.2s;
+    box-shadow: none;
+
     &:hover {
-        border-color: ${cy(0.6)};
-        transform: translateY(-3px);
-        box-shadow: 0 10px 32px ${ac(0.12)};
+        background: var(--dir-row-hover);
+        border-color: var(--dir-border-table);
+        box-shadow: none;
     }
 `;
 
 export const CardHead = styled.div`
-    padding: 14px 16px;
+    padding: var(--space-3) var(--space-4);
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
-    gap: 12px;
+    gap: var(--space-3);
     cursor: pointer;
     user-select: none;
-    &:hover {
-        background: var(--dir-overlay-sm);
-    }
 `;
 
 export const CardLeft = styled.div`
@@ -226,9 +247,9 @@ export const CardLeft = styled.div`
 `;
 
 export const CardName = styled.div`
-    font-weight: 700;
-    font-size: 14px;
-    margin-bottom: 2px;
+    font-weight: var(--font-weight-bold);
+    font-size: var(--font-size-subhead);
+    margin-bottom: var(--space-1);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -238,12 +259,24 @@ export const CardRight = styled.div`
     display: flex;
     flex-direction: column;
     align-items: flex-end;
-    gap: 5px;
+    gap: var(--space-1);
     flex-shrink: 0;
 `;
 
+export const MobileMetaBadgesRow = styled.div`
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+    margin-top: var(--space-2);
+
+    @media (min-width: 768px) {
+        display: none;
+    }
+`;
+
 export const Chevron = styled.span<{ $open: boolean }>`
-    font-size: 10px;
+    font-size: var(--font-size-caption-1);
     color: var(--tertiary-foreground);
     transition: transform 0.18s;
     transform: ${(p) => (p.$open ? "rotate(180deg)" : "rotate(0deg)")};
@@ -252,36 +285,38 @@ export const Chevron = styled.span<{ $open: boolean }>`
 
 export const CardDivider = styled.div`
     height: 1px;
-    background: var(--dir-overlay-md);
-    margin: 0 16px;
+    background: var(--dir-border-table);
+    margin: 0 var(--space-4);
 `;
 
 export const CardBody = styled.div<{ $open: boolean }>`
     display: ${(p) => (p.$open ? "block" : "none")};
-    padding: 14px 16px;
+    padding: var(--space-3) var(--space-4);
     animation: ${fadeUp} 0.15s ease both;
 `;
 
 export const SectionLabel = styled.div`
-    font-size: 10px;
-    font-weight: 700;
-    color: var(--dir-accent);
+    font-size: var(--font-size-caption-1);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-text-primary);
     text-transform: uppercase;
-    letter-spacing: 0.1em;
-    margin: 12px 0 6px;
+    letter-spacing: 0.08em;
+    margin: var(--space-3) 0 var(--space-2);
+
     &:first-child {
         margin-top: 0;
     }
 `;
 
 export const InfoLine = styled.div`
-    font-size: 12px;
+    font-size: var(--font-size-footnote);
     color: var(--secondary-foreground);
-    margin-bottom: 4px;
-    line-height: 1.5;
+    margin-bottom: var(--space-1);
+    line-height: var(--line-height-loose);
+
     strong {
         color: var(--foreground);
-        font-weight: 600;
+        font-weight: var(--font-weight-semibold);
     }
 `;
 
@@ -289,22 +324,24 @@ export const InfoLine = styled.div`
 
 export const TableWrap = styled.div`
     border: 1px solid var(--dir-border-table);
-    border-radius: 10px;
+    border-radius: var(--radius-lg);
     overflow-x: auto;
     overflow-y: hidden;
     -webkit-overflow-scrolling: touch;
     background: var(--dir-surface-table);
-    box-shadow: 0 2px 16px ${ac(0.07)};
+    box-shadow: none;
 
     @media (min-width: 768px) {
         scrollbar-width: thin;
-        scrollbar-color: ${cy(0.4)} transparent;
+        scrollbar-color: var(--color-border-strong) transparent;
+
         &::-webkit-scrollbar {
-            height: 4px;
+            height: var(--space-1);
         }
+
         &::-webkit-scrollbar-thumb {
-            background: ${cy(0.4)};
-            border-radius: 2px;
+            background: var(--color-border-strong);
+            border-radius: var(--radius-xs);
         }
     }
 `;
@@ -313,22 +350,23 @@ export const Table = styled.table`
     width: 100%;
     min-width: 900px;
     border-collapse: collapse;
-    font-size: 13px;
+    font-size: var(--font-size-subhead);
 
     @media (max-width: 1200px) {
-        font-size: 12px;
+        font-size: var(--font-size-footnote);
+
         th,
         td {
-            padding: 9px 10px;
+            padding: var(--space-2) var(--space-3);
         }
     }
 
     th {
-        padding: 11px 13px;
+        padding: var(--space-3) var(--space-3);
         text-align: left;
-        font-size: 10px;
-        font-weight: 700;
-        color: var(--dir-thead-color);
+        font-size: var(--font-size-caption-1);
+        font-weight: var(--font-weight-bold);
+        color: var(--color-text-primary);
         text-transform: uppercase;
         letter-spacing: 0.08em;
         white-space: nowrap;
@@ -337,36 +375,40 @@ export const Table = styled.table`
         background: var(--dir-surface-thead);
         border-bottom: 1px solid var(--dir-border-table);
         transition: color 0.12s;
+
         &:hover {
-            color: var(--foreground);
+            color: var(--dir-accent);
         }
     }
 
     td {
-        padding: 10px 13px;
+        padding: var(--space-2) var(--space-3);
         border-top: 1px solid var(--dir-border-table);
         vertical-align: middle;
-        background: var(--dir-surface-table);
+        background: #06000A ;
+        color: var(--color-text-primary);
+        transition: color 0.12s;
     }
 
     tbody tr:hover td {
-        background: var(--dir-row-hover);
+        background: #1C1720;
     }
 `;
 
 export const TableName = styled.div`
-    font-weight: 700;
-    font-size: 13px;
-    color: var(--foreground);
+    font-weight: var(--font-weight-bold);
+    font-size: var(--font-size-subhead);
+    color: var(--color-text-primary);
     display: flex;
     align-items: center;
-    gap: 5px;
-    margin-bottom: 1px;
+    gap: var(--space-1);
+    margin-bottom: var(--space-1);
+    transition: color 0.12s;
 
     .verified {
-        font-size: 11px;
-        color: #00b4d8;
-        font-weight: 700;
+        font-size: var(--font-size-caption-1);
+        color: var(--color-success);
+        font-weight: var(--font-weight-bold);
         flex-shrink: 0;
     }
 `;
@@ -374,16 +416,18 @@ export const TableName = styled.div`
 export const TableMeta = styled.div`
     display: flex;
     align-items: center;
-    gap: 5px;
-    font-size: 11px;
-    color: var(--secondary-foreground);
+    gap: var(--space-1);
+    font-size: var(--font-size-caption-1);
+    color: var(--color-text-primary);
     flex-wrap: nowrap;
     white-space: nowrap;
+    transition: color 0.12s;
 
     .sep {
         color: var(--block);
         user-select: none;
     }
+
     .online {
         color: var(--success);
     }
@@ -393,12 +437,13 @@ export const TableMeta = styled.div`
 
 export const EmptyState = styled.div`
     text-align: center;
-    padding: clamp(40px, 12vw, 72px) clamp(16px, 4vw, 20px);
+    padding: var(--space-12) var(--space-5);
     color: var(--tertiary-foreground);
+
     .icon {
-        font-size: clamp(28px, 8vw, 36px);
+        font-size: var(--font-size-title-1);
         display: block;
-        margin-bottom: 12px;
-        opacity: 0.4;
+        margin-bottom: var(--space-3);
+        opacity: 1;
     }
 `;

--- a/src/pages/directory/stylesHero.ts
+++ b/src/pages/directory/stylesHero.ts
@@ -1,45 +1,59 @@
 import styled from "styled-components/macro";
-import { cy, ac, fadeUp } from "./stylesLayout";
+
+import { fadeUp } from "./stylesLayout";
 
 // ─── Hero ─────────────────────────────────────────────────────────────────────
 
 export const Hero = styled.section`
-    background: linear-gradient(160deg, var(--dir-hero-from) 0%, var(--dir-hero-mid) 58%, var(--dir-hero-to) 100%);
-    padding: clamp(28px, 6vw, 48px) clamp(14px, 4vw, 24px) clamp(28px, 5vw, 40px);
+    background: linear-gradient(
+        160deg,
+        var(--dir-hero-from) 0%,
+        var(--dir-hero-mid) 58%,
+        var(--dir-hero-to) 100%
+    );
+    padding: var(--space-8) var(--space-4) var(--space-8);
     text-align: center;
     position: relative;
     overflow: hidden;
     border-bottom: none;
 
     @media (max-width: 480px) {
-        padding-left: max(14px, env(safe-area-inset-left, 0px));
-        padding-right: max(14px, env(safe-area-inset-right, 0px));
+        padding-left: max(var(--space-4), env(safe-area-inset-left, 0px));
+        padding-right: max(var(--space-4), env(safe-area-inset-right, 0px));
     }
 
     @media (max-height: 480px) and (orientation: landscape) {
-        padding-top: 20px;
-        padding-bottom: 20px;
+        padding-top: var(--space-5);
+        padding-bottom: var(--space-5);
     }
 
     &::before {
-        content: '';
+        content: "";
         position: absolute;
         inset: 0;
-        background-image: radial-gradient(rgba(255,255,255,0.12) 1px, transparent 1px);
-        background-size: 24px 24px;
+        background-image: radial-gradient(
+            var(--color-border-quiet) var(--space-1),
+            transparent var(--space-1)
+        );
+        background-size: var(--space-6) var(--space-6);
         pointer-events: none;
         z-index: 0;
     }
 
     &::after {
-        content: '';
+        content: "";
         position: absolute;
-        bottom: -80px;
+        bottom: calc(var(--space-16) * -1);
         left: 50%;
         transform: translateX(-50%);
         width: min(700px, 100vw);
         height: 400px;
-        background: radial-gradient(ellipse at 50% 80%, ${cy(0.35)} 0%, ${ac(0.12)} 50%, transparent 75%);
+        background: radial-gradient(
+            ellipse at 50% 80%,
+            var(--color-accent) 0%,
+            var(--color-accent-darker) 50%,
+            transparent 75%
+        );
         pointer-events: none;
         z-index: 0;
     }
@@ -51,31 +65,40 @@ export const HeroInner = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 16px;
+    gap: var(--space-4);
     width: 100%;
     max-width: min(560px, 100%);
     margin: 0 auto;
     box-sizing: border-box;
-    padding: 0 clamp(0px, 2vw, 4px);
-    @media (max-width: 480px) { gap: 14px; padding: 0; }
+    padding: 0;
+
+    @media (max-width: 480px) {
+        gap: var(--space-3);
+    }
 `;
 
 export const HeroTitle = styled.h1`
-    font-size: clamp(1.1875rem, 0.5rem + 4.2vw, 1.75rem);
-    font-weight: 800;
-    letter-spacing: -0.5px;
-    line-height: 1.2;
+    font-size: var(--font-size-title-1);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: 0;
+    line-height: var(--line-height-tight);
     margin: 0;
-    color: #ffffff;
-    span { color: #90e0ef; }
-    @media (max-width: 480px) { letter-spacing: -0.35px; }
+    color: var(--color-text-primary);
+
+    span {
+        color: var(--color-text-tertiary);
+    }
+
+    @media (max-width: 480px) {
+        font-size: var(--font-size-title-2);
+    }
 `;
 
 export const HeroSub = styled.p`
-    font-size: clamp(0.8125rem, 0.72rem + 0.35vw, 0.875rem);
-    color: rgba(202,240,248,0.85);
+    font-size: var(--font-size-callout);
+    color: var(--color-text-secondary);
     margin: 0;
-    line-height: 1.6;
+    line-height: var(--line-height-loose);
     max-width: min(440px, 100%);
     width: 100%;
     box-sizing: border-box;
@@ -83,196 +106,356 @@ export const HeroSub = styled.p`
 
 export const TabToggle = styled.div`
     display: inline-flex;
-    background: rgba(3,4,94,0.4);
-    border: 1px solid rgba(255,255,255,0.14);
-    border-radius: 7px;
-    padding: 3px;
-    gap: 3px;
+    background: var(--color-surface-alt);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-1);
+    gap: var(--space-1);
     max-width: 100%;
     box-sizing: border-box;
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
-    @media (max-width: 400px) { width: 100%; justify-content: stretch; }
+
+    @media (max-width: 400px) {
+        width: 100%;
+        justify-content: stretch;
+    }
 `;
 
 export const ToggleTab = styled.button<{ $active: boolean }>`
-    padding: 7px 22px;
-    border-radius: 5px;
+    padding: var(--space-2) var(--space-5);
+    border-radius: var(--radius-sm);
     border: none;
     cursor: pointer;
-    font-size: 13px;
-    font-weight: 600;
+    font-size: var(--font-size-subhead);
+    font-weight: var(--font-weight-semibold);
     transition: all 0.15s;
-    background: ${(p) => (p.$active ? "#ffffff" : "transparent")};
-    color: ${(p) => (p.$active ? "#03045e" : "rgba(202,240,248,0.75)")};
-    box-shadow: ${(p) => (p.$active ? "0 2px 10px rgba(0,0,0,0.2)" : "none")};
+    background: ${(p) =>
+        p.$active ? "var(--color-surface-inverse)" : "transparent"};
+    color: ${(p) =>
+        p.$active
+            ? "var(--color-text-inverse)"
+            : "var(--color-text-secondary)"};
+    box-shadow: ${(p) => (p.$active ? "var(--shadow-sm)" : "none")};
 
     &:hover {
-        background: ${(p) => (p.$active ? "#ffffff" : "rgba(255,255,255,0.1)")};
-        color: ${(p) => (p.$active ? "#03045e" : "#ffffff")};
+        background: ${(p) =>
+            p.$active
+                ? "var(--color-surface-inverse)"
+                : "var(--color-surface)"};
+        color: ${(p) =>
+            p.$active
+                ? "var(--color-text-inverse)"
+                : "var(--color-text-primary)"};
     }
 
-    @media (max-width: 480px) { padding: 7px 14px; font-size: 13px; }
-    @media (max-width: 400px) { flex: 1; padding: 8px 8px; font-size: 12px; }
+    @media (max-width: 480px) {
+        padding: var(--space-2) var(--space-3);
+        font-size: var(--font-size-subhead);
+    }
+
+    @media (max-width: 400px) {
+        flex: 1;
+        padding: var(--space-2) var(--space-2);
+        font-size: var(--font-size-footnote);
+    }
 `;
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 export const Main = styled.main`
+    flex: 1;
     max-width: 1440px;
     margin: 0 auto;
-    padding: clamp(18px, 2.5vw, 28px) clamp(12px, 3.5vw, 28px) 60px;
+    padding: var(--space-5) var(--space-3) var(--space-16);
     width: 100%;
     box-sizing: border-box;
 
     @media (max-width: 767px) {
-        padding-bottom: calc(100px + env(safe-area-inset-bottom, 0px));
+        padding-bottom: calc(var(--space-16) + var(--space-10));
     }
 
     @media (max-width: 480px) {
-        padding-left: max(12px, env(safe-area-inset-left, 0px));
-        padding-right: max(12px, env(safe-area-inset-right, 0px));
+        padding-left: max(var(--space-3), env(safe-area-inset-left, 0px));
+        padding-right: max(var(--space-3), env(safe-area-inset-right, 0px));
     }
 `;
 
 export const SectionHeader = styled.div`
     display: flex;
     align-items: baseline;
-    gap: 10px;
-    margin-bottom: 18px;
+    gap: var(--space-2);
+    margin-bottom: var(--space-4);
     flex-wrap: wrap;
 
     h2 {
-        font-size: clamp(1rem, 0.92rem + 0.35vw, 1.0625rem);
-        font-weight: 700;
+        font-size: var(--font-size-body-2);
+        font-weight: var(--font-weight-bold);
         margin: 0;
-        letter-spacing: -0.2px;
+        letter-spacing: 0;
         color: var(--foreground);
     }
-    .count { font-size: 13px; color: var(--tertiary-foreground); }
 
-    @media (max-width: 480px) { margin-bottom: 14px; h2 { font-size: 16px; } }
+    .count {
+        font-size: var(--font-size-subhead);
+        color: var(--tertiary-foreground);
+    }
 `;
 
 // ─── Filter ───────────────────────────────────────────────────────────────────
 
 export const FilterWrap = styled.div`
     display: flex;
-    gap: 10px;
-    margin-bottom: 16px;
+    gap: var(--space-2);
+    margin-bottom: var(--space-4);
     flex-wrap: wrap;
-    align-items: center;
-    @media (max-width: 767px) { gap: 8px; }
+    align-items: flex-start;
 `;
 
 export const SearchWrap = styled.label`
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 0 14px;
-    border-radius: 6px;
-    border: 1px solid var(--block);
-    background: var(--secondary-background);
+    gap: var(--space-2);
+    padding: 0 var(--space-3);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
     width: 240px;
+    height: var(--space-8);
     flex-shrink: 0;
     box-sizing: border-box;
     transition: border-color 0.14s;
-    &:focus-within { border-color: var(--dir-accent); }
-    .icon { font-size: 13px; opacity: 0.45; flex-shrink: 0; }
 
-    @media (max-width: 1024px) { flex: 1 1 200px; width: auto; min-width: 0; max-width: min(360px, 100%); }
-    @media (max-width: 767px) { flex: 1 1 100%; width: 100%; max-width: none; }
+    &:focus-within {
+        border-color: var(--dir-accent);
+    }
+
+    .icon {
+        font-size: var(--font-size-subhead);
+        opacity: 1;
+        color: var(--color-icon-secondary);
+        flex-shrink: 0;
+    }
+
+    @media (max-width: 1024px) {
+        flex: 1 1 200px;
+        width: auto;
+        min-width: 0;
+        max-width: min(360px, 100%);
+    }
+
+    @media (max-width: 767px) {
+        flex: 1;
+        width: auto;
+        max-width: none;
+    }
 `;
 
 export const SearchInput = styled.input`
     flex: 1;
-    padding: 8px 0;
+    padding: 0;
+    height: 100%;
     border: none;
     background: transparent;
     color: var(--foreground);
-    font-size: 13px;
+    font-size: var(--font-size-subhead);
     font-family: inherit;
-    &::placeholder { color: var(--tertiary-foreground); }
-    &:focus { outline: none; }
+
+    &::placeholder {
+        color: var(--color-text-disabled);
+    }
+
+    &:focus {
+        outline: none;
+    }
 `;
 
-export const FilterPills = styled.div`
+export const FilterToggleBtn = styled.button<{ $active?: boolean }>`
+    background: var(--color-surface);
+    border: 1px solid
+        ${(p) => (p.$active ? "var(--dir-accent)" : "var(--color-border)")};
+    border-radius: var(--radius-md);
+    color: ${(p) =>
+        p.$active ? "var(--dir-accent)" : "var(--color-text-primary)"};
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 0 var(--space-3);
+    height: var(--space-8);
+    cursor: pointer;
+    transition: all 0.14s;
+    outline: none;
+    flex-shrink: 0;
+
+    &:hover {
+        border-color: var(--dir-accent);
+        color: var(--dir-accent);
+    }
+
+    svg {
+        width: var(--space-4);
+        height: var(--space-4);
+        fill: currentColor;
+    }
+
+    @media (max-width: 767px) {
+        display: flex;
+    }
+`;
+
+export const MobileBreak = styled.div`
+    display: none;
+
+    @media (max-width: 767px) {
+        display: block;
+        flex-basis: 100%;
+        height: 0;
+    }
+`;
+
+export const FilterPills = styled.div<{ $showMobile: boolean }>`
     display: flex;
-    gap: 6px;
+    gap: var(--space-2);
     flex-wrap: wrap;
     align-items: center;
     flex: 1;
     min-width: 0;
-    @media (max-width: 767px) { flex: 1 1 100%; }
+
+    @media (max-width: 767px) {
+        display: ${(p) => (p.$showMobile ? "flex" : "none")};
+        flex: 1 1 100%;
+        width: 100%;
+        background: var(--color-surface);
+        padding: var(--space-3) var(--space-4);
+        border-radius: var(--radius-lg);
+        border: 1px solid var(--color-border);
+        box-shadow: none;
+        animation: ${fadeUp} 0.15s ease both;
+    }
 `;
 
 export const Pill = styled.button<{ $active: boolean }>`
     display: flex;
     align-items: center;
-    gap: 4px;
-    padding: 5px 11px;
-    border-radius: 6px;
-    border: 1px solid ${(p) => (p.$active ? "var(--dir-accent)" : "var(--block)")};
-    background: ${(p) => (p.$active ? ac(0.12) : "transparent")};
-    color: ${(p) => (p.$active ? "var(--dir-accent)" : "var(--secondary-foreground)")};
-    font-size: 12px;
-    font-weight: ${(p) => (p.$active ? 600 : 400)};
+    gap: var(--space-1);
+    padding: 0 var(--space-3);
+    height: var(--space-8);
+    border-radius: var(--radius-pill);
+    border: 1px solid
+        ${(p) => (p.$active ? "var(--dir-accent)" : "var(--color-border)")};
+    background: ${(p) =>
+        p.$active ? "var(--color-accent-darker)" : "var(--color-surface)"};
+    color: var(--color-text-primary);
+    font-size: var(--font-size-footnote);
+    font-weight: ${(p) =>
+        p.$active
+            ? "var(--font-weight-semibold)"
+            : "var(--font-weight-regular)"};
     cursor: pointer;
     white-space: nowrap;
     transition: all 0.12s;
-    &:hover { border-color: var(--dir-accent); color: var(--dir-accent); background: ${ac(0.07)}; }
-    @media (max-width: 480px) { min-height: 36px; padding: 6px 12px; }
+
+    &:hover {
+        border-color: var(--dir-accent);
+        background: var(--color-accent-darker);
+    }
+
+    @media (max-width: 480px) {
+        min-height: var(--space-8);
+        padding: var(--space-2) var(--space-3);
+    }
 `;
 
 export const ClearBtn = styled.button`
-    padding: 5px 10px;
+    padding: var(--space-1) var(--space-2);
     border: none;
     background: none;
     color: var(--tertiary-foreground);
-    font-size: 12px;
+    font-size: var(--font-size-footnote);
     cursor: pointer;
     transition: color 0.12s;
-    &:hover { color: var(--dir-accent); }
+
+    &:hover {
+        color: var(--dir-accent);
+    }
 `;
 
 export const LegendToggle = styled.button`
-    padding: 5px 12px;
-    border: 1px solid var(--block);
-    border-radius: 6px;
+    padding: 0 var(--space-3);
+    height: var(--space-8);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
     background: transparent;
     color: var(--tertiary-foreground);
-    font-size: 12px;
+    font-size: var(--font-size-footnote);
     cursor: pointer;
     white-space: nowrap;
     transition: all 0.12s;
-    &:hover { border-color: var(--secondary-foreground); color: var(--foreground); }
-    @media (max-width: 767px) { flex: 0 0 auto; align-self: flex-start; }
+
+    &:hover {
+        border-color: var(--secondary-foreground);
+        color: var(--foreground);
+    }
+
+    @media (max-width: 767px) {
+        flex: 0 0 auto;
+        align-self: flex-start;
+    }
 `;
 
 export const LegendBox = styled.div`
-    background: var(--dir-surface-card);
-    border: 1px solid var(--dir-border-card);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
     backdrop-filter: blur(10px);
-    border-radius: 8px;
-    padding: 18px 22px;
-    margin-bottom: 16px;
+    border-radius: var(--radius-lg);
+    padding: var(--space-5) var(--space-6);
+    margin-bottom: var(--space-4);
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-    gap: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: var(--space-6) var(--space-8);
     animation: ${fadeUp} 0.18s ease both;
 
-    @media (max-width: 767px) { padding: 14px 16px; grid-template-columns: repeat(auto-fill, minmax(min(100%, 140px), 1fr)); gap: 12px; }
-    @media (max-width: 380px) { grid-template-columns: 1fr; }
+    @media (max-width: 767px) {
+        padding: var(--space-4);
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+    }
+
+    @media (max-width: 480px) {
+        grid-template-columns: 1fr;
+    }
 `;
 
 export const LegendCat = styled.div`
-    h4 { font-size: 10px; font-weight: 700; color: var(--dir-accent); text-transform: uppercase; letter-spacing: 0.1em; margin: 0 0 8px; }
-    ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; }
-    li {
-        font-size: 12px;
-        color: var(--secondary-foreground);
+    h4 {
+        font-size: var(--font-size-caption-1);
+        font-weight: var(--font-weight-bold);
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        margin: 0 0 var(--space-2);
+    }
+
+    ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
         display: flex;
-        gap: 8px;
-        span { font-weight: 700; color: var(--foreground); min-width: 30px; }
+        flex-direction: column;
+        gap: var(--space-2);
+    }
+
+    li {
+        font-size: var(--font-size-footnote);
+        color: var(--color-text-primary);
+        display: flex;
+        align-items: flex-start;
+        gap: var(--space-3);
+        line-height: var(--line-height-loose);
+
+        span {
+            font-weight: var(--font-weight-bold);
+            color: var(--color-text-primary);
+            min-width: var(--space-16);
+            flex-shrink: 0;
+        }
     }
 `;

--- a/src/pages/directory/stylesLayout.ts
+++ b/src/pages/directory/stylesLayout.ts
@@ -3,99 +3,114 @@ import styled, { css, keyframes } from "styled-components/macro";
 // ─── Animations ───────────────────────────────────────────────────────────────
 
 export const fadeUp = keyframes`
-    from { opacity: 0; transform: translateY(10px); }
-    to   { opacity: 1; transform: translateY(0); }
+    from { opacity: 0; transform: translateY(var(--space-2)); }
+    to   { opacity: 1; transform: translateY(var(--space-0)); }
 `;
 
 // ─── Color helpers ────────────────────────────────────────────────────────────
 
-export const ac = (a: number) => `rgba(0,119,182,${a})`;
-export const cy = (a: number) => `rgba(0,180,216,${a})`;
-export const gr = (a: number) => `rgba(16,185,129,${a})`;
-export const or = (a: number) => `rgba(250,163,82,${a})`;
-export const bk = (a: number) => `rgba(0,0,0,${a})`;
+export const ac = (_a: number) => "var(--color-accent)";
+export const cy = (_a: number) => "var(--color-info)";
+export const gr = (_a: number) => "var(--color-success)";
+export const or = (_a: number) => "var(--color-caution)";
+export const bk = (_a: number) => "var(--color-bg)";
 
 // ─── Page wrapper ─────────────────────────────────────────────────────────────
 
 export const Page = styled.div<{ $dark?: boolean }>`
     height: 100%;
+    min-height: 100%;
     width: 100%;
     max-width: 100vw;
     box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
     overflow-y: auto;
     overflow-x: hidden;
-    font-family: var(--font, "Inter", "Open Sans"), sans-serif;
-    font-size: 14px;
+    font-family: var(--font-family);
+    font-size: var(--font-size-body-4);
     -webkit-tap-highlight-color: transparent;
 
-    --dir-accent:          #0077b6;
-    --background:          #caf0f8;
-    --primary-background:  #FFFFFF;
-    --secondary-background:#e8f8fc;
-    --foreground:          #03045e;
-    --secondary-foreground:#0077b6;
-    --tertiary-foreground: #00b4d8;
-    --block:               rgba(0,119,182,0.18);
-    --success:             #10B981;
-    --warning:             #F59E0B;
-    --error:               #EF4444;
+    --dir-accent: var(--color-accent);
+    --background: var(--color-bg);
+    --primary-background: var(--color-surface);
+    --secondary-background: var(--color-surface-alt);
+    --foreground: var(--color-text-primary);
+    --secondary-foreground: var(--color-text-secondary);
+    --tertiary-foreground: var(--color-text-tertiary);
+    --block: var(--color-border);
+    --success: var(--color-success);
+    --warning: var(--color-warning);
+    --error: var(--color-danger);
 
-    --dir-surface-nav:    #03045e;
-    --dir-surface-card:   #FFFFFF;
-    --dir-surface-modal:  rgba(255,255,255,0.97);
-    --dir-surface-table:  #f0fafd;
-    --dir-surface-thead:  #ddf3fa;
-    --dir-row-hover:      #e2f5fb;
-    --dir-hero-from:      #03045e;
-    --dir-hero-mid:       #0077b6;
-    --dir-hero-to:        #00b4d8;
-    --dir-border-nav:     rgba(0,180,216,0.25);
-    --dir-border-card:    rgba(0,180,216,0.2);
-    --dir-border-table:   rgba(0,119,182,0.18);
-    --dir-thead-color:    #0077b6;
-    --dir-overlay-sm:     rgba(0,0,0,0.03);
-    --dir-overlay-md:     rgba(0,0,0,0.07);
-    --dir-overlay-lg:     rgba(0,0,0,0.12);
-    --dir-modal-shadow:   0 8px 40px rgba(0,119,182,0.18), 0 2px 8px rgba(0,0,0,0.08);
+    --dir-surface-nav: var(--color-surface-alt);
+    --dir-surface-card: var(--color-surface);
+    --dir-surface-modal: var(--color-surface);
+    --dir-surface-table: var(--color-surface);
+    --dir-surface-thead: var(--color-surface-alt);
+    --dir-row-hover: var(--color-accent-darker);
+    --dir-hero-from: var(--color-bg);
+    --dir-hero-mid: var(--color-accent-darker);
+    --dir-hero-to: var(--color-accent);
+    --dir-border-nav: var(--color-border-quiet);
+    --dir-border-card: var(--color-border);
+    --dir-border-table: var(--color-border-quiet);
+    --dir-thead-color: var(--color-text-secondary);
+    --dir-overlay-sm: var(--color-surface-alt);
+    --dir-overlay-md: var(--color-border-quiet);
+    --dir-overlay-lg: var(--color-border-strong);
+    --dir-modal-shadow: var(--shadow-md);
 
-    ${(p) => p.$dark && css`
-        --background:          #01060f;
-        --primary-background:  #031d33;
-        --secondary-background:#042540;
-        --foreground:          #caf0f8;
-        --secondary-foreground:#90e0ef;
-        --tertiary-foreground: rgba(144,224,239,0.55);
-        --block:               rgba(0,180,216,0.22);
-        --success:             #34d399;
-        --warning:             #fbbf24;
+    ${(p) =>
+        p.$dark &&
+        css`
+            --background: var(--color-bg);
+            --primary-background: var(--color-surface);
+            --secondary-background: var(--color-surface-alt);
+            --foreground: var(--color-text-primary);
+            --secondary-foreground: var(--color-text-secondary);
+            --tertiary-foreground: var(--color-text-tertiary);
+            --block: var(--color-border);
+            --success: var(--color-success);
+            --warning: var(--color-warning);
 
-        --dir-surface-nav:    #010c1a;
-        --dir-surface-card:   #031d33;
-        --dir-surface-modal:  rgba(3,29,51,0.98);
-        --dir-surface-table:  #031d33;
-        --dir-surface-thead:  #042540;
-        --dir-row-hover:      #053050;
-        --dir-hero-from:      #010c1a;
-        --dir-hero-mid:       #03045e;
-        --dir-hero-to:        #0077b6;
-        --dir-border-nav:     rgba(0,180,216,0.2);
-        --dir-border-card:    rgba(0,180,216,0.15);
-        --dir-border-table:   rgba(0,180,216,0.12);
-        --dir-thead-color:    #90e0ef;
-        --dir-overlay-sm:     rgba(255,255,255,0.04);
-        --dir-overlay-md:     rgba(255,255,255,0.08);
-        --dir-overlay-lg:     rgba(255,255,255,0.14);
-        --dir-modal-shadow:   0 8px 40px rgba(0,0,0,0.5), 0 2px 8px rgba(0,0,0,0.3);
-    `}
+            --dir-surface-nav: var(--color-surface-alt);
+            --dir-surface-card: var(--color-surface);
+            --dir-surface-modal: var(--color-surface);
+            --dir-surface-table: var(--color-surface);
+            --dir-surface-thead: var(--color-surface-alt);
+            --dir-row-hover: var(--color-accent-darker);
+            --dir-hero-from: var(--color-bg);
+            --dir-hero-mid: var(--color-accent-darker);
+            --dir-hero-to: var(--color-accent);
+            --dir-border-nav: var(--color-border-quiet);
+            --dir-border-card: var(--color-border);
+            --dir-border-table: var(--color-border-quiet);
+            --dir-thead-color: var(--color-text-secondary);
+            --dir-overlay-sm: var(--color-surface-alt);
+            --dir-overlay-md: var(--color-border-quiet);
+            --dir-overlay-lg: var(--color-border-strong);
+            --dir-modal-shadow: var(--shadow-md);
+        `}
 
     background: var(--background);
     color: var(--foreground);
 
     scrollbar-width: thin;
-    scrollbar-color: ${cy(0.5)} transparent;
-    &::-webkit-scrollbar { width: 4px; }
-    &::-webkit-scrollbar-thumb { background: ${cy(0.5)}; border-radius: 2px; }
-    &::-webkit-scrollbar-track { background: transparent; }
+    scrollbar-color: var(--color-border-strong) transparent;
+
+    &::-webkit-scrollbar {
+        width: var(--space-1);
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background: var(--color-border-strong);
+        border-radius: var(--radius-xs);
+    }
+
+    &::-webkit-scrollbar-track {
+        background: transparent;
+    }
 `;
 
 // ─── Header ───────────────────────────────────────────────────────────────────
@@ -105,58 +120,116 @@ export const Header = styled.header`
     backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
     border-bottom: 1px solid var(--dir-border-nav);
-    padding: 0 24px;
-    height: 56px;
+    padding: 0 var(--space-6);
+    height: calc(var(--space-12) + var(--space-2));
     box-sizing: border-box;
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: var(--space-4);
     position: sticky;
     top: 0;
     z-index: 100;
-    min-width: 0;
 
-    @media (max-width: 1024px) { padding: 0 18px; }
-    @media (max-width: 768px) { padding: 0 14px; gap: 10px; }
-    @media (max-width: 480px) { padding: 0 12px; gap: 8px; }
+    @media (max-width: 767px) {
+        padding-left: var(--space-3);
+        padding-right: var(--space-5);
+        gap: var(--space-3);
+    }
 `;
 
 export const LogoImg = styled.img`
-    height: 22px;
+    height: var(--space-5);
     display: block;
     flex-shrink: 0;
-    @media (max-width: 360px) { height: 19px; }
+
+    @media (max-width: 360px) {
+        height: var(--space-4);
+    }
+`;
+
+export const BrandGroup = styled.div`
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+
+    @media (max-width: 767px) {
+        gap: var(--space-1);
+    }
+`;
+
+export const BrandText = styled.span`
+    font-family: var(--font-family);
+    font-size: var(--font-size-title-1);
+    font-weight: var(--font-weight-bold);
+    line-height: var(--line-height-tight);
+    color: var(--color-text-primary);
+    letter-spacing: 0;
+
+    @media (max-width: 767px) {
+        font-size: var(--font-size-title-3);
+    }
+`;
+
+export const SidebarToggle = styled.button`
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+    height: calc(var(--space-8) + var(--space-2));
+    padding: 0 var(--space-2);
+    border: 0;
+    background: transparent;
+    color: var(--color-icon-primary);
+    cursor: pointer;
+    flex-shrink: 0;
+
+    &:hover {
+        color: var(--color-icon-tertiary);
+    }
+
+    > svg + svg {
+        margin-left: calc(var(--space-1) * -1);
+    }
 `;
 
 export const DirectoryBadge = styled.span`
-    font-size: 11px;
-    font-weight: 700;
+    font-size: var(--font-size-caption-1);
+    font-weight: var(--font-weight-bold);
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    padding: 3px 8px;
-    border-radius: 20px;
-    background: ${cy(0.15)};
-    color: #90e0ef;
-    border: 1px solid ${cy(0.3)};
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--radius-pill);
+    background: var(--color-accent-darker);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-accent);
     flex-shrink: 0;
-    @media (max-width: 500px) { display: none; }
+
+    @media (max-width: 500px) {
+        display: none;
+    }
 `;
 
-export const HeaderSpacer = styled.div`flex: 1; min-width: 8px;`;
+export const HeaderSpacer = styled.div`
+    flex: 1;
+    min-width: var(--space-2);
+`;
 
 export const HeaderNav = styled.nav`
     display: flex;
     align-items: center;
-    gap: 8px;
-    @media (max-width: 500px) { gap: 6px; }
+    gap: var(--space-2);
+
+    @media (max-width: 500px) {
+        gap: var(--space-2);
+    }
 `;
 
 export const NavBtn = styled.a<{ $primary?: boolean }>`
     && {
-        padding: 7px 16px;
-        border-radius: 6px;
-        font-size: 13px;
-        font-weight: 600;
+        padding: var(--space-2) var(--space-4);
+        border-radius: var(--radius-md);
+        font-size: var(--font-size-subhead);
+        font-weight: var(--font-weight-semibold);
         text-decoration: none !important;
         cursor: pointer;
         transition: all 0.15s;
@@ -166,46 +239,70 @@ export const NavBtn = styled.a<{ $primary?: boolean }>`
         line-height: 1;
 
         ${(p) =>
-        p.$primary
-            ? css`
-                background: var(--dir-accent);
-                color: #fff !important;
-                border: 1px solid var(--dir-accent);
-                &:hover { filter: brightness(1.1); box-shadow: 0 4px 14px ${ac(0.4)}; text-decoration: none !important; }
-            `
-            : css`
-                background: transparent;
-                color: rgba(202,240,248,0.8) !important;
-                border: 1px solid rgba(255,255,255,0.15);
-                &:hover { background: rgba(255,255,255,0.08); color: #ffffff !important; border-color: rgba(255,255,255,0.3); text-decoration: none !important; }
-            `}
+            p.$primary
+                ? css`
+                      background: var(--dir-accent);
+                      color: var(--color-text-primary) !important;
+                      border: 1px solid var(--dir-accent);
 
-        @media (max-width: 380px) { padding: 6px 12px; font-size: 12px; }
+                      &:hover {
+                          background: var(--color-accent-deep);
+                          box-shadow: var(--shadow-sm);
+                          text-decoration: none !important;
+                      }
+                  `
+                : css`
+                      background: transparent;
+                      color: var(--color-text-secondary) !important;
+                      border: 1px solid var(--color-border);
+
+                      &:hover {
+                          background: var(--color-surface);
+                          color: var(--color-text-primary) !important;
+                          border-color: var(--color-border-strong);
+                          text-decoration: none !important;
+                      }
+                  `}
+
+        @media (max-width: 380px) {
+            padding: var(--space-2) var(--space-3);
+            font-size: var(--font-size-footnote);
+        }
     }
 `;
 
 export const DesktopAuthGroup = styled.div`
     display: flex;
     align-items: center;
-    gap: 8px;
-    @media (max-width: 500px) { display: none; }
+    gap: var(--space-2);
+
+    @media (max-width: 500px) {
+        display: none;
+    }
 `;
 
 export const MobileAuthBtn = styled.a`
     && {
         display: none;
-        padding: 7px 14px;
-        border-radius: 6px;
-        font-size: 13px;
-        font-weight: 600;
+        padding: var(--space-2) var(--space-3);
+        border-radius: var(--radius-md);
+        font-size: var(--font-size-subhead);
+        font-weight: var(--font-weight-semibold);
         text-decoration: none !important;
         cursor: pointer;
         white-space: nowrap;
         background: var(--dir-accent);
-        color: #fff !important;
+        color: var(--color-text-primary) !important;
         border: 1px solid var(--dir-accent);
         transition: all 0.15s;
-        &:hover { filter: brightness(1.1); }
-        @media (max-width: 500px) { display: inline-flex; align-items: center; }
+
+        &:hover {
+            background: var(--color-accent-deep);
+        }
+
+        @media (max-width: 500px) {
+            display: inline-flex;
+            align-items: center;
+        }
     }
 `;

--- a/src/pages/directory/stylesModal.ts
+++ b/src/pages/directory/stylesModal.ts
@@ -1,201 +1,310 @@
 import styled from "styled-components/macro";
-import { ac, fadeUp } from "./stylesLayout";
+
+import { fadeUp } from "./stylesLayout";
 
 // ─── Modals ───────────────────────────────────────────────────────────────────
 
 export const Overlay = styled.div`
     position: fixed;
     inset: 0;
-    background: rgba(0,0,0,0.75);
+    background: var(--color-scrim);
     backdrop-filter: blur(6px);
     -webkit-backdrop-filter: blur(6px);
     z-index: 1000;
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: max(12px, env(safe-area-inset-top, 0px)) max(12px, env(safe-area-inset-right, 0px))
-        max(12px, env(safe-area-inset-bottom, 0px)) max(12px, env(safe-area-inset-left, 0px));
+    padding: max(var(--space-3), env(safe-area-inset-top, 0px))
+        max(var(--space-3), env(safe-area-inset-right, 0px))
+        max(var(--space-3), env(safe-area-inset-bottom, 0px))
+        max(var(--space-3), env(safe-area-inset-left, 0px));
     box-sizing: border-box;
-    @media (max-width: 768px) { align-items: flex-end; padding: 0; padding-bottom: env(safe-area-inset-bottom, 0px); }
+
+    @media (max-width: 768px) {
+        align-items: flex-end;
+        padding: 0;
+        padding-bottom: env(safe-area-inset-bottom, 0px);
+    }
 `;
 
 export const ModalBox = styled.div<{ $wide?: boolean }>`
     background: var(--dir-surface-modal);
+    color: var(--foreground);
     border: 1px solid var(--dir-border-card);
     backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
-    border-radius: 8px;
+    border-radius: var(--radius-lg);
     width: 100%;
     max-width: ${(p) => (p.$wide ? "580px" : "540px")};
     max-height: 88vh;
     overflow-y: auto;
     box-shadow: var(--dir-modal-shadow);
     animation: ${fadeUp} 0.18s ease both;
-    @media (max-width: 768px) { border-radius: 12px 12px 0 0; max-height: 92vh; border-bottom: none; padding-bottom: env(safe-area-inset-bottom, 0px); }
-    @media (max-width: 480px) { max-height: 92vh; }
+
+    @media (max-width: 768px) {
+        border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+        max-height: 92vh;
+        border-bottom: none;
+        padding-bottom: env(safe-area-inset-bottom, 0px);
+    }
+
+    @media (max-width: 480px) {
+        max-height: 92vh;
+    }
 `;
 
 export const DragHandle = styled.div`
     display: none;
-    width: 32px; height: 3px;
+    width: var(--space-8);
+    height: var(--space-1);
     background: var(--dir-overlay-lg);
-    border-radius: 2px;
-    margin: 8px auto 0;
-    @media (max-width: 768px) { display: block; }
+    border-radius: var(--radius-xs);
+    margin: var(--space-2) auto 0;
+
+    @media (max-width: 768px) {
+        display: block;
+    }
 `;
 
 export const ModalHead = styled.div`
-    padding: 18px 22px 14px;
+    padding: var(--space-5) var(--space-6) var(--space-4);
     border-bottom: 1px solid var(--dir-overlay-md);
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
-    gap: 12px;
-    h2 { font-size: 16px; font-weight: 700; margin: 0 0 4px; letter-spacing: -0.2px; }
-    @media (max-width: 480px) { padding: 14px 16px 12px; h2 { font-size: 15px; } }
+    gap: var(--space-3);
+
+    h2 {
+        font-size: var(--font-size-body-2);
+        font-weight: var(--font-weight-bold);
+        margin: 0 0 var(--space-1);
+        letter-spacing: 0;
+        color: var(--color-text-primary);
+    }
+
+    @media (max-width: 480px) {
+        padding: var(--space-4) var(--space-4) var(--space-3);
+
+        h2 {
+            font-size: var(--font-size-body-3);
+        }
+    }
 `;
 
 export const ModalClose = styled.button`
-    background: var(--dir-overlay-md);
-    border: none;
-    color: var(--secondary-foreground);
-    width: 26px; height: 26px;
-    border-radius: 50%;
-    display: flex; align-items: center; justify-content: center;
-    font-size: 13px;
+    background: var(--color-surface-alt);
+    border: 1px solid var(--color-border);
+    color: var(--color-text-primary);
+    width: var(--space-6);
+    height: var(--space-6);
+    padding: 0;
+    border-radius: var(--radius-pill);
+    display: grid;
+    place-items: center;
+    font-size: var(--font-size-subhead);
+    line-height: 1;
     cursor: pointer;
     flex-shrink: 0;
     transition: all 0.12s;
-    &:hover { background: var(--dir-accent); color: white; }
+
+    &:hover {
+        background: var(--dir-accent);
+        color: var(--color-text-primary);
+    }
 `;
 
 export const ModalBody = styled.div`
-    padding: 18px 22px;
-    @media (max-width: 480px) { padding: 14px 16px 18px; }
+    padding: var(--space-5) var(--space-6);
+
+    @media (max-width: 480px) {
+        padding: var(--space-4) var(--space-4) var(--space-5);
+    }
 `;
 
 // ─── Form Elements ────────────────────────────────────────────────────────────
 
 export const FormGroup = styled.div`
-    margin-bottom: 14px;
+    margin-bottom: var(--space-3);
 
     label {
         display: block;
-        font-size: 10px;
-        font-weight: 700;
-        color: var(--dir-accent);
+        font-size: var(--font-size-caption-1);
+        font-weight: var(--font-weight-bold);
+        color: var(--color-text-primary);
         text-transform: uppercase;
         letter-spacing: 0.1em;
-        margin-bottom: 6px;
+        margin-bottom: var(--space-2);
     }
 
-    input[type="text"], input[type="url"], textarea {
+    input[type="text"],
+    input[type="url"],
+    textarea {
         width: 100%;
-        padding: 8px 12px;
-        border-radius: 6px;
-        border: 1px solid var(--block);
-        background: var(--secondary-background);
+        padding: var(--space-2) var(--space-3);
+        border-radius: var(--radius-md);
+        border: 1px solid var(--color-border);
+        background: var(--color-surface-alt);
         color: var(--foreground);
-        font-size: 13px;
+        font-size: var(--font-size-subhead);
         font-family: inherit;
         box-sizing: border-box;
         transition: border-color 0.12s;
-        &::placeholder { color: var(--tertiary-foreground); }
-        &:focus { outline: none; border-color: var(--dir-accent); }
+
+        &::placeholder {
+            color: var(--tertiary-foreground);
+        }
+
+        &:focus {
+            outline: none;
+            border-color: var(--dir-accent);
+        }
     }
 
-    textarea { min-height: 78px; resize: vertical; }
+    textarea {
+        min-height: 78px;
+        resize: vertical;
+    }
 `;
 
-export const CheckboxGrid = styled.div`display: flex; flex-wrap: wrap; gap: 6px;`;
+export const CheckboxGrid = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+`;
 
 export const CheckLabel = styled.label<{ $checked: boolean }>`
     display: flex;
     align-items: center;
-    gap: 5px;
-    padding: 5px 10px;
-    border-radius: 6px;
-    border: 1px solid ${(p) => (p.$checked ? "var(--dir-accent)" : "var(--block)")};
-    background: ${(p) => (p.$checked ? ac(0.1) : "transparent")};
+    gap: var(--space-1);
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--radius-md);
+    border: 1px solid
+        ${(p) => (p.$checked ? "var(--dir-accent)" : "var(--color-border)")};
+    background: ${(p) =>
+        p.$checked ? "var(--color-accent-darker)" : "var(--color-surface-alt)"};
     cursor: pointer;
-    font-size: 12px;
-    font-weight: ${(p) => (p.$checked ? 600 : 400)};
-    color: ${(p) => (p.$checked ? "var(--dir-accent)" : "var(--secondary-foreground)")};
+    font-size: var(--font-size-footnote);
+    font-weight: ${(p) =>
+        p.$checked
+            ? "var(--font-weight-semibold)"
+            : "var(--font-weight-regular)"};
+    color: ${(p) =>
+        p.$checked
+            ? "var(--color-text-primary)"
+            : "var(--secondary-foreground)"};
     transition: all 0.1s;
-    input { display: none; }
-    &:hover { border-color: var(--dir-accent); }
+
+    input {
+        display: none;
+    }
+
+    &:hover {
+        border-color: var(--dir-accent);
+    }
 `;
 
 export const TypeToggle = styled.div`
     display: flex;
-    gap: 8px;
-    margin-bottom: 18px;
+    gap: var(--space-2);
+    margin-bottom: var(--space-4);
     flex-wrap: wrap;
-    @media (max-width: 380px) { flex-direction: column; }
+
+    @media (max-width: 380px) {
+        flex-direction: column;
+    }
 `;
 
 export const TypeBtn = styled.button<{ $active: boolean }>`
     flex: 1;
-    padding: 9px;
-    border-radius: 6px;
-    border: 1px solid ${(p) => (p.$active ? "var(--dir-accent)" : "var(--block)")};
-    background: ${(p) => (p.$active ? ac(0.12) : "var(--secondary-background)")};
-    color: ${(p) => (p.$active ? "var(--dir-accent)" : "var(--secondary-foreground)")};
-    font-size: 14px;
-    font-weight: 600;
+    padding: var(--space-2);
+    border-radius: var(--radius-md);
+    border: 1px solid
+        ${(p) => (p.$active ? "var(--dir-accent)" : "var(--color-border)")};
+    background: ${(p) =>
+        p.$active
+            ? "var(--color-accent-darker)"
+            : "var(--secondary-background)"};
+    color: ${(p) =>
+        p.$active
+            ? "var(--color-text-primary)"
+            : "var(--secondary-foreground)"};
+    font-size: var(--font-size-body-4);
+    font-weight: var(--font-weight-semibold);
     cursor: pointer;
     transition: all 0.12s;
-    &:hover { border-color: var(--dir-accent); }
+
+    &:hover {
+        border-color: var(--dir-accent);
+    }
 `;
 
 export const PrimaryBtn = styled.button`
     width: 100%;
-    padding: 11px;
-    border-radius: 6px;
-    border: none;
+    padding: var(--space-3);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--dir-accent);
     background: var(--dir-accent);
-    color: white;
-    font-size: 14px;
-    font-weight: 700;
+    color: var(--color-text-primary);
+    font-size: var(--font-size-body-4);
+    font-weight: var(--font-weight-bold);
     cursor: pointer;
-    margin-top: 6px;
+    margin-top: var(--space-2);
     transition: all 0.15s;
-    &:hover { filter: brightness(1.1); box-shadow: 0 4px 14px ${ac(0.35)}; }
-    &:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    &:hover {
+        background: var(--color-accent-deep);
+        box-shadow: var(--shadow-sm);
+    }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
 `;
 
 export const ErrorMsg = styled.div`
-    color: var(--error);
-    font-size: 12px;
-    margin-bottom: 10px;
-    padding: 7px 11px;
-    background: rgba(237,66,69,0.08);
-    border-radius: 6px;
-    border: 1px solid rgba(237,66,69,0.2);
+    color: var(--color-danger);
+    font-size: var(--font-size-footnote);
+    margin-bottom: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    background: var(--color-danger-subtle);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-danger-border);
 `;
 
 export const SuccessMsg = styled.div`
     text-align: center;
-    padding: 18px 0;
-    color: var(--success);
-    font-size: 14px;
-    font-weight: 600;
+    padding: var(--space-5) 0;
+    color: var(--color-success);
+    font-size: var(--font-size-body-4);
+    font-weight: var(--font-weight-semibold);
 `;
 
 // ─── Review cards ─────────────────────────────────────────────────────────────
 
 export const RevCard = styled.div`
-    padding: 12px 0;
+    padding: var(--space-3) 0;
     border-bottom: 1px solid var(--dir-overlay-md);
-    &:last-child { border-bottom: none; }
+
+    &:last-child {
+        border-bottom: none;
+    }
 `;
 
 export const RevMeta = styled.div`
     display: flex;
     align-items: center;
-    gap: 9px;
-    margin-bottom: 6px;
+    gap: var(--space-2);
+    margin-bottom: var(--space-2);
     flex-wrap: wrap;
-    .name { font-weight: 600; font-size: 13px; }
-    .date { font-size: 11px; color: var(--tertiary-foreground); }
+
+    .name {
+        font-weight: var(--font-weight-semibold);
+        font-size: var(--font-size-subhead);
+    }
+
+    .date {
+        font-size: var(--font-size-caption-1);
+        color: var(--tertiary-foreground);
+    }
 `;

--- a/src/pages/directory/stylesNav.ts
+++ b/src/pages/directory/stylesNav.ts
@@ -1,5 +1,4 @@
 import styled from "styled-components/macro";
-import { ac, cy } from "./stylesLayout";
 
 // ─── Mobile Bottom Nav ────────────────────────────────────────────────────────
 
@@ -19,23 +18,29 @@ export const BottomNav = styled.div`
 
 export const BottomTab = styled.button<{ $active: boolean }>`
     flex: 1;
-    padding: 12px 10px;
+    padding: var(--space-3) var(--space-2);
     border: none;
     background: transparent;
-    color: ${(p) => (p.$active ? "#90e0ef" : "rgba(202,240,248,0.45)")};
-    font-size: 12px;
-    font-weight: ${(p) => (p.$active ? 700 : 400)};
+    color: ${(p) =>
+        p.$active
+            ? "var(--color-text-primary)"
+            : "var(--color-text-secondary)"};
+    font-size: var(--font-size-footnote);
+    font-weight: ${(p) =>
+        p.$active ? "var(--font-weight-bold)" : "var(--font-weight-regular)"};
     cursor: pointer;
     transition: color 0.14s;
     position: relative;
 
     &::after {
-        content: '';
+        content: "";
         position: absolute;
-        bottom: 0; left: 20%; right: 20%;
-        height: 2px;
-        background: #00b4d8;
-        border-radius: 2px 2px 0 0;
+        bottom: 0;
+        left: 20%;
+        right: 20%;
+        height: var(--space-1);
+        background: var(--color-accent);
+        border-radius: var(--radius-xs) var(--radius-xs) 0 0;
         transform: scaleX(${(p) => (p.$active ? 1 : 0)});
         transition: transform 0.18s;
     }
@@ -43,49 +48,56 @@ export const BottomTab = styled.button<{ $active: boolean }>`
 
 export const FAB = styled.button`
     position: fixed;
-    bottom: 28px;
-    right: 28px;
-    width: 52px;
-    height: 52px;
-    border-radius: 50%;
+    bottom: var(--space-8);
+    right: var(--space-8);
+    width: var(--space-12);
+    height: var(--space-12);
+    border-radius: var(--radius-pill);
     background: var(--dir-accent);
-    border: none;
-    color: white;
-    font-size: 24px;
+    border: 1px solid var(--color-accent-deep);
+    color: var(--color-text-primary);
+    font-size: var(--font-size-title-2);
     cursor: pointer;
-    box-shadow: 0 4px 16px ${ac(0.45)};
+    box-shadow: var(--shadow-sm);
     z-index: 51;
     display: flex;
     align-items: center;
     justify-content: center;
     transition: all 0.15s;
-    &:hover { filter: brightness(1.1); transform: scale(1.05); }
+    &:hover {
+        background: var(--color-accent-deep);
+        transform: scale(1.05);
+    }
 
     @media (max-width: 768px) {
-        bottom: calc(64px + env(safe-area-inset-bottom, 0px));
-        right: max(18px, env(safe-area-inset-right, 0px));
+        bottom: calc(var(--space-16) + env(safe-area-inset-bottom, 0px));
+        right: max(var(--space-4), env(safe-area-inset-right, 0px));
     }
 `;
 
 // ─── Footer ───────────────────────────────────────────────────────────────────
 
 export const Footer = styled.footer`
-    --footer-logo-h: 22px;
+    --footer-logo-h: var(--space-5);
     background: var(--dir-surface-nav);
     border-top: 1px solid var(--dir-border-nav);
-    padding: 24px 28px;
+    padding: var(--space-6) var(--space-8);
     display: flex;
     align-items: center;
     justify-content: space-between;
     flex-wrap: wrap;
-    gap: 12px;
+    gap: var(--space-3);
 
-    .left { display: flex; align-items: center; gap: 12px; }
+    .left {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+    }
     .disclaimer {
-        font-size: 12px;
-        color: rgba(202,240,248,0.55);
+        font-size: var(--font-size-footnote);
+        color: var(--color-text-secondary);
         max-width: 480px;
-        line-height: 1.5;
+        line-height: var(--line-height-loose);
         margin: 0;
         margin-left: calc(var(--footer-logo-h) * 157 / 240);
     }
@@ -93,75 +105,99 @@ export const Footer = styled.footer`
     @media (max-width: 767px) {
         flex-direction: column;
         align-items: flex-start;
-        padding: 20px clamp(12px, 3.5vw, 18px);
-        .disclaimer { max-width: 100%; }
+        padding: var(--space-5) var(--space-3);
+        .disclaimer {
+            max-width: 100%;
+        }
     }
 
     @media (max-width: 480px) {
-        padding: 18px max(12px, env(safe-area-inset-left, 0px)) 18px max(12px, env(safe-area-inset-right, 0px));
+        padding: var(--space-4)
+            max(var(--space-3), env(safe-area-inset-left, 0px)) var(--space-4)
+            max(var(--space-3), env(safe-area-inset-right, 0px));
     }
 `;
 
 export const FooterLinks = styled.div`
     display: flex;
     flex-wrap: wrap;
-    gap: 12px 16px;
+    gap: var(--space-3) var(--space-4);
     align-items: center;
     a {
-        font-size: 12px;
-        color: rgba(202,240,248,0.7) !important;
+        font-size: var(--font-size-footnote);
+        color: var(--color-text-secondary) !important;
         text-decoration: none !important;
         transition: color 0.12s;
-        &:hover { color: #90e0ef !important; }
+        &:hover {
+            color: var(--color-text-primary) !important;
+        }
     }
 `;
 
 // ─── Theme Toggle + Nav extras ────────────────────────────────────────────────
 
 export const ThemeToggle = styled.button`
-    width: 34px;
-    height: 34px;
-    border-radius: 50%;
-    border: 1px solid rgba(255,255,255,0.18);
-    background: rgba(255,255,255,0.08);
-    color: #caf0f8;
-    font-size: 16px;
+    width: calc(var(--space-8) + var(--space-1));
+    height: calc(var(--space-8) + var(--space-1));
+    border-radius: var(--radius-pill);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text-tertiary);
+    font-size: var(--font-size-body-2);
     cursor: pointer;
-    display: flex;
+    display: none;
     align-items: center;
     justify-content: center;
     transition: all 0.15s;
     flex-shrink: 0;
     line-height: 1;
-    &:hover { background: rgba(255,255,255,0.16); border-color: rgba(255,255,255,0.35); transform: rotate(20deg); }
-    @media (max-width: 500px) { width: 30px; height: 30px; font-size: 14px; }
+    &:hover {
+        background: var(--color-surface-alt);
+        border-color: var(--color-border-strong);
+        color: var(--color-text-primary);
+        transform: rotate(20deg);
+    }
+    @media (max-width: 500px) {
+        width: var(--space-8);
+        height: var(--space-8);
+        font-size: var(--font-size-body-4);
+    }
 `;
 
 export const NavDivider = styled.div`
     width: 1px;
-    height: 20px;
-    background: rgba(255,255,255,0.15);
+    height: var(--space-5);
+    background: var(--color-border);
     flex-shrink: 0;
-    @media (max-width: 560px) { display: none; }
+    @media (max-width: 560px) {
+        display: none;
+    }
 `;
 
 export const NavSubmitGroup = styled.div`
     display: flex;
     align-items: center;
-    gap: 6px;
-    @media (max-width: 560px) { display: none; }
+    gap: var(--space-2);
 `;
 
 export const NavSubmitBtn = styled.button`
-    padding: 6px 13px;
-    border-radius: 6px;
-    font-size: 12px;
-    font-weight: 600;
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-footnote);
+    font-weight: var(--font-weight-semibold);
     cursor: pointer;
     transition: all 0.15s;
     white-space: nowrap;
-    border: 1px solid ${cy(0.45)};
-    background: ${cy(0.12)};
-    color: #90e0ef;
-    &:hover { background: ${cy(0.22)}; border-color: #00b4d8; color: #caf0f8; }
+    background: var(--dir-accent);
+    color: var(--color-text-primary) !important;
+    border: 1px solid var(--dir-accent);
+    &:hover {
+        background: var(--color-accent-deep);
+        box-shadow: var(--shadow-sm);
+    }
+
+    @media (max-width: 560px) {
+        padding: var(--space-1) var(--space-2);
+        font-size: var(--font-size-caption-1);
+    }
 `;

--- a/src/pages/directory/types.ts
+++ b/src/pages/directory/types.ts
@@ -44,7 +44,7 @@ export interface CommunityBase {
     type: "vendor" | "reseller" | "other";
     name: string;
     logo?: string | null;
-    inviteLink: string;
+    inviteLink: string | null;
     serverId?: string | null;
     ageDays: number;
     verified: boolean;
@@ -52,6 +52,9 @@ export interface CommunityBase {
     onlineCount: number;
     rating: number;
     notes: string;
+    sortorder?: number;
+    locked?: boolean;
+    joinable?: boolean;
 }
 
 export interface VendorCommunity extends CommunityBase {
@@ -108,12 +111,19 @@ export interface SubmitForm {
     guarantees: Guarantees;
     guaranteeTexts: GuaranteeTexts;
     orderTypes: OrderTypes;
+    proofs: File[];
+    externalLinks: string;
+    coas: string;
+    shortDescription: string;
     notes: string;
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-export const PAYMENT_LABELS: Record<Exclude<keyof Payment, 'custom'>, string> = {
+export const PAYMENT_LABELS: Record<
+    Exclude<keyof Payment, "custom">,
+    string
+> = {
     cc: "CC",
     btc: "BTC",
     pp: "PP",
@@ -128,7 +138,10 @@ export const WAREHOUSE_LABELS: Record<string, string> = {
     aus: "AUS",
     cn: "CN",
 };
-export const PRODUCT_LABELS: Record<Exclude<keyof Products, 'custom'>, string> = {
+export const PRODUCT_LABELS: Record<
+    Exclude<keyof Products, "custom">,
+    string
+> = {
     pep: "PEP",
     oil: "OIL",
     tabs: "TABS",
@@ -203,11 +216,12 @@ export const LEGEND = [
         ],
     },
     {
-        category: "Countries",
+        category: "Warehouse Locations",
         items: [
             { abbr: "US", label: "United States" },
             { abbr: "EU", label: "Europe" },
             { abbr: "AUS", label: "Australia" },
+            { abbr: "CN", label: "China" },
         ],
     },
     {
@@ -249,13 +263,8 @@ export const LEGEND = [
     },
 ];
 
-// ─── Sheet URLs ───────────────────────────────────────────────────────────────
-
-export const SHEET_COMMUNITIES =
-    "https://docs.google.com/spreadsheets/d/e/2PACX-1vRIOkigL7Zu8jsYMF0AKu8CAw1az-8EFiAhHCrXBzSASrhQDocU-U5mezf2u08uO_imVvWvmi3rH-NX/pub?gid=0&single=true&output=csv";
-export const SHEET_REVIEWS =
-    "https://docs.google.com/spreadsheets/d/e/2PACX-1vRIOkigL7Zu8jsYMF0AKu8CAw1az-8EFiAhHCrXBzSASrhQDocU-U5mezf2u08uO_imVvWvmi3rH-NX/pub?gid=1967322747&single=true&output=csv";
-
 // ─── Live API ─────────────────────────────────────────────────────────────────
 
-export const API_BASE = import.meta.env.VITE_API_BASE || "/api";
+export const API_BASE =
+    import.meta.env.VITE_API_BASE ||
+    (import.meta.env.PROD ? "https://manageapi.peptide.chat/api" : "/api");

--- a/src/pages/directory/useDirectory.ts
+++ b/src/pages/directory/useDirectory.ts
@@ -1,13 +1,6 @@
 import { useState, useMemo, useEffect } from "preact/hooks";
 
-import {
-    parseCSV,
-    rowToCommunity,
-    rowToReview,
-    apiToCommunity,
-    apiToReview,
-    matchesFilters,
-} from "./dataUtils";
+import { apiToCommunity, apiToReview, matchesFilters } from "./dataUtils";
 import type {
     Community,
     CommerceCommunity,
@@ -15,7 +8,7 @@ import type {
     FilterKey,
     SubmitForm,
 } from "./types";
-import { API_BASE, SHEET_COMMUNITIES, SHEET_REVIEWS } from "./types";
+import { API_BASE } from "./types";
 
 export function useDirectory() {
     const [tab, setTab] = useState<"vendors" | "resellers" | "other">(
@@ -25,8 +18,8 @@ export function useDirectory() {
     const [activeFilters, setActiveFilters] = useState<Set<FilterKey>>(
         new Set(),
     );
-    const [sortCol, setSortCol] = useState<"rating" | "name">("rating");
-    const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
+    const [sortCol, setSortCol] = useState<"rank" | "rating" | "name">("rank");
+    const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
     const [reviews, setReviews] = useState<Review[]>([]);
     /** Live mode: review counts from GET reviews pagination (list is empty until a modal fetch). */
     const [reviewTotals, setReviewTotals] = useState<Record<string, number>>(
@@ -36,6 +29,7 @@ export function useDirectory() {
     const [loading, setLoading] = useState(true);
     const [loadError, setLoadError] = useState<string | null>(null);
     const [showLegend, setShowLegend] = useState(false);
+    const [showFilters, setShowFilters] = useState(false);
     const [reviewModal, setReviewModal] = useState<Community | null>(null);
     const [submitOpen, setSubmitOpen] = useState(false);
     const [submitInitialType, setSubmitInitialType] = useState<
@@ -43,65 +37,36 @@ export function useDirectory() {
     >("vendor");
     const [darkMode, setDarkMode] = useState(false);
 
-    const useLive = useMemo(
-        () => new URLSearchParams(window.location.search).has("live"),
-        [],
-    );
-
-    // Load communities (+ reviews for sheet mode)
+    // Load communities from the live API
     useEffect(() => {
         let cancelled = false;
         setLoading(true);
         setLoadError(null);
 
-        if (useLive) {
-            fetch(`${API_BASE}/directory/communities?limit=100`)
-                .then((r) => r.json())
-                .then((json) => {
-                    if (cancelled) return;
-                    const list = Array.isArray(json.data) 
-                        ? json.data 
-                        : (json.data?.items ?? json.items ?? []);
-                    setAllCommunities(list.map(apiToCommunity));
-                })
-                .catch((err) => {
-                    if (!cancelled) setLoadError(String(err));
-                })
-                .finally(() => {
-                    if (!cancelled) setLoading(false);
-                });
-        } else {
-            Promise.all([
-                fetch(SHEET_COMMUNITIES).then((r) => r.text()),
-                fetch(SHEET_REVIEWS).then((r) => r.text()),
-            ])
-                .then(([commCSV, revCSV]) => {
-                    if (cancelled) return;
-                    const communities = parseCSV(commCSV)
-                        .map(rowToCommunity)
-                        .filter(Boolean) as Community[];
-                    const reviewList = parseCSV(revCSV)
-                        .map(rowToReview)
-                        .filter(Boolean) as Review[];
-                    setAllCommunities(communities);
-                    setReviews(reviewList);
-                })
-                .catch((err) => {
-                    if (!cancelled) setLoadError(String(err));
-                })
-                .finally(() => {
-                    if (!cancelled) setLoading(false);
-                });
-        }
+        fetch(`${API_BASE}/directory/communities?limit=100`)
+            .then((r) => r.json())
+            .then((json) => {
+                if (cancelled) return;
+                const list = Array.isArray(json.data)
+                    ? json.data
+                    : json.data?.items ?? json.items ?? [];
+                setAllCommunities(list.map(apiToCommunity));
+            })
+            .catch((err) => {
+                if (!cancelled) setLoadError(String(err));
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
 
         return () => {
             cancelled = true;
         };
-    }, [useLive]);
+    }, []);
 
-    // Live mode: load per-listing review totals (rating comes from communities; counts need reviews meta)
+    // Load per-listing review totals (rating comes from communities; counts need reviews meta)
     useEffect(() => {
-        if (!useLive || allCommunities.length === 0) return;
+        if (allCommunities.length === 0) return;
         let cancelled = false;
         Promise.all(
             allCommunities.map((c) =>
@@ -130,11 +95,11 @@ export function useDirectory() {
         return () => {
             cancelled = true;
         };
-    }, [useLive, allCommunities]);
+    }, [allCommunities]);
 
-    // In live mode: fetch reviews for a community when its modal opens
+    // Fetch reviews for a community when its modal opens
     useEffect(() => {
-        if (!useLive || !reviewModal) return;
+        if (!reviewModal) return;
         let cancelled = false;
         fetch(
             `${API_BASE}/directory/communities/reviews?communityId=${reviewModal.id}&pageSize=50`,
@@ -152,7 +117,7 @@ export function useDirectory() {
         return () => {
             cancelled = true;
         };
-    }, [useLive, reviewModal?.id]);
+    }, [reviewModal?.id]);
 
     function openSubmit(type: "vendor" | "reseller" | "other") {
         setSubmitInitialType(type);
@@ -167,7 +132,7 @@ export function useDirectory() {
         });
     }
 
-    function handleSort(col: "rating" | "name") {
+    function handleSort(col: "rank" | "rating" | "name") {
         if (sortCol === col) setSortDir((d) => (d === "asc" ? "desc" : "asc"));
         else {
             setSortCol(col);
@@ -200,10 +165,15 @@ export function useDirectory() {
                 return matchesFilters(c as CommerceCommunity, activeFilters);
             })
             .sort((a, b) => {
-                const cmp =
-                    sortCol === "rating"
-                        ? a.rating - b.rating
-                        : a.name.localeCompare(b.name);
+                let cmp = 0;
+                if (sortCol === "rank") {
+                    cmp = (a.sortorder || 0) - (b.sortorder || 0);
+                    if (cmp === 0) cmp = b.rating - a.rating; // Tie breaker: higher rating
+                } else if (sortCol === "rating") {
+                    cmp = a.rating - b.rating;
+                } else {
+                    cmp = a.name.localeCompare(b.name);
+                }
                 return sortDir === "asc" ? cmp : -cmp;
             });
     }, [allCommunities, tab, tabType, search, activeFilters, sortCol, sortDir]);
@@ -217,71 +187,57 @@ export function useDirectory() {
     };
 
     function handleSubmitReview(rev: Omit<Review, "id" | "date">) {
-        if (useLive) {
-            fetch(`${API_BASE}/directory/communities/reviews`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    communityId: rev.vendorId,
-                    communityType: rev.vendorType,
-                    reviewerName: rev.reviewerName,
-                    rating: rev.rating,
-                    text: rev.text,
-                }),
-            }).catch(() => {});
-        } else {
-            setReviews((prev) => [
-                ...prev,
-                {
-                    ...rev,
-                    id: `u${Date.now()}`,
-                    date: new Date().toISOString().split("T")[0],
-                },
-            ]);
-        }
+        fetch(`${API_BASE}/directory/communities/reviews`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                communityId: rev.vendorId,
+                communityType: rev.vendorType,
+                reviewerName: rev.reviewerName,
+                rating: rev.rating,
+                text: rev.text,
+            }),
+        }).catch(() => {});
     }
 
     function handleSubmitListing(form: SubmitForm) {
-        if (useLive) {
-            const isCommerce = form.type === "vendor" || form.type === "reseller";
+        const isCommerce = form.type === "vendor" || form.type === "reseller";
 
-            // Build the single `guarantee` object the backend expects:
-            // { purity, purityDesc, volume, volumeDesc, reship, reshipDesc }
-            const guarantee = isCommerce
-                ? {
-                      purity: form.guarantees.purity,
-                      purityDesc: form.guaranteeTexts.purity || undefined,
-                      volume: form.guarantees.volume,
-                      volumeDesc: form.guaranteeTexts.volume || undefined,
-                      reship: form.guarantees.reship,
-                      reshipDesc: form.guaranteeTexts.reship || undefined,
-                  }
-                : undefined;
+        // Build the single `guarantee` object the backend expects:
+        // { purity, purityDesc, volume, volumeDesc, reship, reshipDesc }
+        const guarantee = isCommerce
+            ? {
+                  purity: form.guarantees.purity,
+                  purityDesc: form.guaranteeTexts.purity || undefined,
+                  volume: form.guarantees.volume,
+                  volumeDesc: form.guaranteeTexts.volume || undefined,
+                  reship: form.guarantees.reship,
+                  reshipDesc: form.guaranteeTexts.reship || undefined,
+              }
+            : undefined;
 
-            fetch(`${API_BASE}/directory/communities/submissions`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    type: form.type,
-                    name: form.name,
-                    inviteLink: form.inviteLink,
-                    serverId: form.serverId || undefined,
-                    ...(isCommerce && {
-                        payment: form.payment,
-                        warehouses: form.warehouses,
-                        products: form.products,
-                        guarantee,
-                        orderTypes: form.type === "reseller" ? form.orderTypes : undefined,
-                    }),
-                    notes: form.notes || undefined,
+        fetch(`${API_BASE}/directory/communities/submissions`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                type: form.type,
+                name: form.name,
+                inviteLink: form.inviteLink,
+                serverId: form.serverId || undefined,
+                ...(isCommerce && {
+                    payment: form.payment,
+                    warehouses: form.warehouses,
+                    products: form.products,
+                    guarantee,
+                    orderTypes:
+                        form.type === "reseller" ? form.orderTypes : undefined,
+                    externalLinks: form.externalLinks || undefined,
+                    coas: form.coas || undefined,
+                    shortDescription: form.shortDescription || undefined,
                 }),
-            }).catch(() => {});
-        } else {
-            const key = "pepchat_pending_submissions";
-            const existing = JSON.parse(localStorage.getItem(key) || "[]");
-            existing.push({ ...form, submittedAt: new Date().toISOString() });
-            localStorage.setItem(key, JSON.stringify(existing));
-        }
+                notes: form.notes || undefined,
+            }),
+        }).catch(() => {});
     }
 
     return {
@@ -296,6 +252,8 @@ export function useDirectory() {
         loadError,
         showLegend,
         setShowLegend,
+        showFilters,
+        setShowFilters,
         reviewModal,
         setReviewModal,
         submitOpen,

--- a/src/pages/home/HomeNew.tsx
+++ b/src/pages/home/HomeNew.tsx
@@ -1,20 +1,51 @@
 import { observer } from "mobx-react-lite";
-import { clientController } from "../../controllers/client/ClientController";
-import wideSVG from "/assets/wide.svg";
-import styles from "./Directory.module.scss";
+import { Home as HomeIcon } from "@styled-icons/boxicons-solid";
+import {
+    ChevronLeft,
+    ChevronRight,
+    Menu,
+} from "@styled-icons/boxicons-regular";
+import { Text } from "preact-i18n";
+import React, { useEffect } from "react";
+import styled from "styled-components/macro";
 
-import { useDirectory } from "./useDirectory";
-import { CommunityCard, CommunityRow } from "./CommunityCard";
-import { ReviewsModal } from "./ReviewsModal";
-import { SubmitModal } from "./SubmitModal";
-import { COMMERCE_FILTERS, LEGEND } from "./types";
+import { PageHeader } from "../../components/ui/Header";
+import { isTouchscreenDevice } from "../../lib/isTouchscreenDevice";
+import { useApplicationState } from "../../mobx/State";
+import { SIDEBAR_CHANNELS } from "../../mobx/stores/Layout";
 
-import { Page, Header, LogoImg, DirectoryBadge, HeaderSpacer, HeaderNav, NavBtn, DesktopAuthGroup, MobileAuthBtn } from "./stylesLayout";
-import { Hero, HeroInner, HeroTitle, HeroSub, TabToggle, ToggleTab, Main, SectionHeader, FilterWrap, SearchWrap, SearchInput, FilterToggleBtn, MobileBreak, FilterPills, Pill, ClearBtn, LegendToggle, LegendBox, LegendCat } from "./stylesHero";
-import { EmptyState, TableWrap, Table, CardGrid } from "./stylesCommunity";
-import { Footer, FooterLinks, BottomNav, BottomTab, FAB, ThemeToggle, NavDivider, NavSubmitGroup, NavSubmitBtn } from "./stylesNav";
+import { useDirectory } from "../directory/useDirectory";
+import { CommunityCard, CommunityRow } from "../directory/CommunityCard";
+import { ReviewsModal } from "../directory/ReviewsModal";
+import { SubmitModal } from "../directory/SubmitModal";
+import { COMMERCE_FILTERS, LEGEND } from "../directory/types";
 
-function Directory() {
+import {
+    Page,
+    Header,
+    DirectoryBadge,
+    HeaderSpacer,
+    BrandGroup,
+    BrandText,
+    SidebarToggle,
+} from "../directory/stylesLayout";
+import { ThemeToggle, NavSubmitGroup, NavSubmitBtn } from "../directory/stylesNav";
+import { TabToggle, ToggleTab, Main, FilterWrap, SearchWrap, SearchInput, FilterPills, FilterToggleBtn, MobileBreak, Pill, ClearBtn, LegendToggle, LegendBox, LegendCat } from "../directory/stylesHero";
+import { EmptyState, TableWrap, Table, CardGrid } from "../directory/stylesCommunity";
+import directoryStyles from "../directory/Directory.module.scss";
+
+const Overlay = styled.div`
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow-y: auto;
+    background: var(--background);
+`;
+
+const HomeNewContent = observer(() => {
+    const layout = useApplicationState().layout;
+    const sidebarVisible = layout.getSectionState(SIDEBAR_CHANNELS, true);
+
     const {
         tab, search, setSearch, activeFilters, setActiveFilters, sortCol, sortDir,
         loading, loadError, showLegend, setShowLegend, showFilters, setShowFilters,
@@ -25,64 +56,71 @@ function Directory() {
     } = useDirectory();
 
     const si = (col: "rating" | "name") => sortCol === col ? (sortDir === "asc" ? " ↑" : " ↓") : "";
-    const loggedIn = clientController.isLoggedIn();
-    const sectionTitle = tab === "vendors" ? "Vendor Communities" : tab === "resellers" ? "Reseller Communities" : "Other Communities";
+
+    useEffect(() => {
+        if (!darkMode) {
+            setDarkMode(true);
+        }
+    }, [darkMode, setDarkMode]);
+
+    function toggleSidebar() {
+        if (isTouchscreenDevice) {
+            document
+                .querySelector("#app > div > div > div")
+                ?.scrollTo({ behavior: "smooth", left: 0 });
+            return;
+        }
+
+        layout.toggleSectionState(SIDEBAR_CHANNELS, true);
+    }
 
     return (
-        <Page $dark={darkMode}>
-            {/* ── Header ── */}
+        <Page $dark={darkMode} style={{ height: "auto", overflow: "visible" }}>
             <Header>
-                <LogoImg src={wideSVG} alt="PepChat" draggable={false} />
+                <BrandGroup>
+                    <SidebarToggle
+                        onClick={toggleSidebar}
+                        title="Toggle sidebar"
+                        aria-label="Toggle sidebar"
+                    >
+                        {isTouchscreenDevice ? (
+                            <Menu size={26} />
+                        ) : (
+                            <>
+                                {sidebarVisible ? (
+                                    <>
+                                        <ChevronLeft size={26} />
+                                        <HomeIcon size={22} />
+                                    </>
+                                ) : (
+                                    <>
+                                        <HomeIcon size={22} />
+                                        <ChevronRight size={26} />
+                                    </>
+                                )}
+                            </>
+                        )}
+                    </SidebarToggle>
+                    <BrandText>PepChat</BrandText>
+                </BrandGroup>
                 <DirectoryBadge>Directory</DirectoryBadge>
                 <HeaderSpacer />
                 <NavSubmitGroup>
                     <NavSubmitBtn onClick={() => openSubmit("vendor")}>+ Vendor</NavSubmitBtn>
                     <NavSubmitBtn onClick={() => openSubmit("reseller")}>+ Reseller</NavSubmitBtn>
                 </NavSubmitGroup>
-                <NavDivider />
                 <ThemeToggle onClick={() => setDarkMode((d) => !d)} title={darkMode ? "Light mode" : "Dark mode"}>
                     {darkMode ? "☀" : "☾"}
                 </ThemeToggle>
-                <NavDivider />
-                <HeaderNav>
-                    {loggedIn ? (
-                        <NavBtn href="/" $primary>Open Chat</NavBtn>
-                    ) : (
-                        <>
-                            <DesktopAuthGroup>
-                                <NavBtn href="/login">Log In</NavBtn>
-                                <NavBtn href="/login/create" $primary>Register</NavBtn>
-                            </DesktopAuthGroup>
-                            <MobileAuthBtn href="/login">Login</MobileAuthBtn>
-                        </>
-                    )}
-                </HeaderNav>
             </Header>
-
-            {/* ── Hero ── */}
-            <Hero>
-                <HeroInner>
-                    <HeroTitle>PepChat <span>Discovery</span></HeroTitle>
-                    <HeroSub>
-                        Community-curated directory of trusted peptide communities.
-                        Compare vendors, resellers, and general communities in one place.
-                    </HeroSub>
+            <Main>
+                <div style={{ marginBottom: "16px" }}>
                     <TabToggle>
                         <ToggleTab $active={tab === "vendors"} onClick={() => switchTab("vendors")}>Vendors</ToggleTab>
                         <ToggleTab $active={tab === "resellers"} onClick={() => switchTab("resellers")}>Resellers</ToggleTab>
                         <ToggleTab $active={tab === "other"} onClick={() => switchTab("other")}>Other</ToggleTab>
                     </TabToggle>
-                </HeroInner>
-            </Hero>
-
-            {/* ── Main ── */}
-            <Main>
-                <SectionHeader>
-                    <h2>{sectionTitle}</h2>
-                    {!loading && !loadError && (
-                        <span className="count">{filtered.length} listing{filtered.length !== 1 ? "s" : ""}</span>
-                    )}
-                </SectionHeader>
+                </div>
 
                 <FilterWrap>
                     <SearchWrap>
@@ -159,7 +197,7 @@ function Directory() {
                     </EmptyState>
                 ) : (
                     <>
-                        <TableWrap className={styles.desktopTable}>
+                        <TableWrap className={directoryStyles.desktopTable}>
                             <Table>
                                 <thead>
                                     <tr>
@@ -194,7 +232,7 @@ function Directory() {
                             </Table>
                         </TableWrap>
 
-                        <CardGrid className={styles.mobileCards}>
+                        <CardGrid className={directoryStyles.mobileCards}>
                             {filtered.map((c) => (
                                 <CommunityCard
                                     key={c.id}
@@ -207,35 +245,6 @@ function Directory() {
                     </>
                 )}
             </Main>
-
-            {/* ── Footer ── */}
-            <Footer>
-                <div>
-                    <LogoImg src={wideSVG} alt="PepChat" draggable={false} style={{ marginBottom: 8 }} />
-                    <p className="disclaimer">
-                        Information is community-maintained and may not be current.
-                        Not affiliated with or endorsing any listed community.
-                    </p>
-                </div>
-                <FooterLinks>
-                    {loggedIn ? (
-                        <a href="/" style={{ color: "inherit", textDecoration: "none" }}>Open Chat</a>
-                    ) : (
-                        <>
-                            <a href="/login" style={{ color: "inherit", textDecoration: "none" }}>Log In</a>
-                            <a href="/login/create" style={{ color: "inherit", textDecoration: "none" }}>Register</a>
-                        </>
-                    )}
-                </FooterLinks>
-            </Footer>
-
-            <BottomNav className={styles.mobileNav}>
-                <BottomTab $active={tab === "vendors"} onClick={() => switchTab("vendors")}>Vendors</BottomTab>
-                <BottomTab $active={tab === "resellers"} onClick={() => switchTab("resellers")}>Resellers</BottomTab>
-                <BottomTab $active={tab === "other"} onClick={() => switchTab("other")}>Other</BottomTab>
-            </BottomNav>
-
-            <FAB onClick={() => setSubmitOpen(true)}>+</FAB>
 
             {/* ── Modals ── */}
             {reviewModal && (
@@ -258,6 +267,17 @@ function Directory() {
             )}
         </Page>
     );
-}
+});
 
-export default observer(Directory);
+const HomeNew: React.FC = () => {
+    return (
+        <Overlay>
+            <PageHeader icon={<HomeIcon size={24} />} withTransparency>
+                <Text id="app.navigation.tabs.home" />
+            </PageHeader>
+            <HomeNewContent />
+        </Overlay>
+    );
+};
+
+export default HomeNew;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -3,8 +3,8 @@
      * Appearance
      */
     --ligatures: none;
-    --text-size: 14px;
-    --font: "Open Sans";
+    --text-size: var(--font-size-body-4);
+    --font: var(--font-family);
     --sidebar-active: var(--secondary-background);
 
     /**
@@ -18,24 +18,25 @@
      * Layout
      */
     --app-height: 100vh;
-    --scrollbar-thickness: 3px;
+    --scrollbar-thickness: var(--space-1);
     --scrollbar-thickness-ff: thin;
-    --border-radius: 6px;
+    --border-radius: var(--radius-md);
     --border-radius-half: 50%;
 
     --border-radius-user-icon: var(--border-radius-half);
     --border-radius-channel-icon: var(--border-radius-half);
     --border-radius-server-icon: var(--border-radius-half);
 
-    --input-border-width: 2px;
-    --textarea-padding: 16px;
-    --textarea-line-height: 20px;
-    --message-box-padding: 14px 14px 14px 0;
+    --input-border-width: 1px;
+    --textarea-padding: var(--space-4);
+    --textarea-line-height: var(--space-5);
+    --message-box-padding: var(--space-3) var(--space-3) var(--space-3)
+        var(--space-0);
 
     --attachment-max-width: 400px;
     --attachment-max-height: 300px;
     --attachment-default-width: 400px;
     --attachment-max-text-width: 800px;
 
-    --bottom-navigation-height: 50px;
+    --bottom-navigation-height: var(--space-12);
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,111 @@
+/* ============================================================
+   Zeko Chat (PepChat) - Design Tokens
+   Source of truth: github.com/archem-team/pepchat-ios
+   ============================================================ */
+
+@import url("https://fonts.googleapis.com/css2?family=Mukta+Mahee:wght@300;400;600;700&display=swap");
+
+:root {
+    /* Colors */
+    --color-bg: #100518;
+    --color-surface: #332e36;
+    --color-surface-alt: #1c1720;
+    --color-surface-inverse: #f3f2f3;
+    --color-accent: #662d91;
+    --color-accent-deep: #492069;
+    --color-accent-darker: #3b1954;
+
+    --color-text-primary: #fffffd;
+    --color-text-secondary: #a3a1a4;
+    --color-text-tertiary: #d0cfd0;
+    --color-text-disabled: #605c62;
+    --color-text-inverse: #100518;
+
+    --color-icon-primary: #fffffd;
+    --color-icon-secondary: #8c8a8e;
+    --color-icon-tertiary: #d0cfd0;
+    --color-icon-inverse: #06000a;
+
+    --color-border: #49454c;
+    --color-border-quiet: #332e36;
+    --color-border-strong: #605c62;
+
+    --color-success: #3cc374;
+    --color-success-border: #246b44;
+    --color-warning: #ffde17;
+    --color-warning-pressed: #dabd15;
+    --color-danger: #c63945;
+    --color-danger-pressed: #a9303c;
+    --color-danger-subtle: #531722;
+    --color-danger-border: #701f2a;
+    --color-info: #17a6ff;
+    --color-caution: #ffb617;
+
+    --color-scrim: rgba(16, 5, 24, 0.6);
+
+    /* Typography */
+    --font-family: "Mukta Mahee", "MuktaMahee", system-ui, -apple-system,
+        sans-serif;
+    --font-weight-light: 300;
+    --font-weight-regular: 400;
+    --font-weight-semibold: 600;
+    --font-weight-bold: 700;
+
+    --font-size-large-title: 32px;
+    --font-size-title-1: 26px;
+    --font-size-title-2: 20px;
+    --font-size-title-3: 18px;
+    --font-size-title-4: 18px;
+    --font-size-headline: 15px;
+    --font-size-body: 15px;
+    --font-size-body-1: 18px;
+    --font-size-body-2: 16px;
+    --font-size-body-3: 15px;
+    --font-size-body-4: 14px;
+    --font-size-button: 15px;
+    --font-size-callout: 14px;
+    --font-size-subhead: 13px;
+    --font-size-footnote: 12px;
+    --font-size-caption-1: 11px;
+
+    --line-height-tight: 1.2;
+    --line-height-normal: 1.35;
+    --line-height-loose: 1.5;
+
+    /* Spacing */
+    --space-0: 0;
+    --space-1: 4px;
+    --space-2: 8px;
+    --space-3: 12px;
+    --space-4: 16px;
+    --space-5: 20px;
+    --space-6: 24px;
+    --space-8: 32px;
+    --space-10: 40px;
+    --space-12: 48px;
+    --space-16: 64px;
+
+    /* Radius */
+    --radius-xs: 2px;
+    --radius-sm: 4px;
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --radius-xl: 20px;
+    --radius-pill: 999px;
+
+    /* Elevation */
+    --shadow-sm: 0 0 2px rgba(16, 5, 24, 0.2);
+    --shadow-md: 0 2px 4px rgba(0, 0, 0, 0.2);
+    --shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+html,
+body {
+    background-color: var(--color-bg);
+    color: var(--color-text-primary);
+    font-family: var(--font-family);
+    font-weight: var(--font-weight-regular);
+    font-size: var(--font-size-body);
+    line-height: var(--line-height-normal);
+    -webkit-font-smoothing: antialiased;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -115,6 +115,18 @@ export default defineConfig({
             preventAssignment: true,
         }) as any,
     ],
+    server: {
+        // Proxy the directory "manage" API in dev so /api/* requests reach the
+        // real backend instead of falling through to the SPA index.html.
+        // Production uses the absolute API_BASE (see src/pages/directory/types.ts).
+        proxy: {
+            "/api": {
+                target: "https://manageapi.peptide.chat",
+                changeOrigin: true,
+                secure: true,
+            },
+        },
+    },
     build: {
         sourcemap: true,
         rollupOptions: {


### PR DESCRIPTION
## Summary

Brings the latest discovery/directory UI onto `master`, switches the directory to live API data only, and adds an embedded discovery page at `/home` that keeps the app sidebars.

## Changes

- **Latest directory UI**: updated `directory/` components and styles (CommunityCard, SubmitModal, useDirectory, types, all `styles*`) to the newest versions, rendered by the standalone `Directory.tsx` page (routing unchanged: `/d1r3ct0ry-b3ta`).
- **New theme app-wide**: added `src/styles/tokens.css` (imported in `main.tsx`) and rewired `_variables.scss` onto the new design tokens.
- **Live data only**: the directory now always fetches the live API. Removed the Google Sheet CSV fallback (dummy data), the `SHEET_*` constants, and the dead CSV parsing helpers. Submit review/listing always POST to the API.
- **Embedded `/home`**: new `home/HomeNew.tsx` (the embedded discovery layout — tabs, filters, table/cards, no DM-search box). It is routed **inside `RevoltApp`** so it keeps the `LeftSidebar`/`HomeSidebar` like `/`. The in-app home (`/`) is reverted to its original behavior.
- **Dev proxy**: added a dev-only Vite proxy for `/api` -> `https://manageapi.peptide.chat` so live data loads in local dev. Production is unaffected (uses the absolute `API_BASE`).

## Routes

| Route | Renders |
|---|---|
| `/` | original in-app home (server list) |
| `/home` | embedded discovery (inside RevoltApp, with sidebars) |
| `/d1r3ct0ry-b3ta` | standalone public Directory page |

## Testing

- Dev server compiles all changed modules (HTTP 200), no new errors.
- Verified the live API loads through the dev proxy (`/api/directory/communities` returns JSON).
- No new TypeScript errors introduced beyond the repo's pre-existing baseline (styled-components-in-Preact and react-router JSX typing noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
