### PR TITLE
feat: migrate directory/promo endpoints to the Rust backend API

### DIFF
--- a/src/pages/directory/types.ts
+++ b/src/pages/directory/types.ts
@@ -265,6 +265,23 @@ export const LEGEND = [
 
 // ─── Live API ─────────────────────────────────────────────────────────────────
 
+// Legacy admin backend ("manage"/"manageapi"). Still serves the endpoints that
+// were NOT ported to the Rust backend:
+//   - directory community reviews   (GET/POST /directory/communities/reviews)
+//   - directory submissions         (POST     /directory/communities/submissions)
+//   - single community detail        (GET      /directory/communities/<id>)
+//   - vendor owner endpoints         (GET      /directory/communities/owner/<id>)
+// In dev these go through the Vite `/api` proxy (see vite.config.ts).
 export const API_BASE =
     import.meta.env.VITE_API_BASE ||
     (import.meta.env.PROD ? "https://manageapi.peptide.chat/api" : "/api");
+
+// New Rust backend (delta). Serves the natively-ported directory/promo
+// endpoints, ALL of which now require auth via the `x-session-token` header:
+//   - GET  /directory/servers
+//   - GET  /directory/communities (listing)   — use pageSize (max 100), NOT limit
+//   - GET  /promos, GET /promos/<id>
+//   - POST /promos/submit
+// This is an absolute URL, so it bypasses the dev `/api` proxy entirely.
+export const BACKEND_API_BASE =
+    import.meta.env.VITE_API_URL?.replace(/\/$/, "") || "https://peptide.chat/api";

--- a/src/pages/directory/useDirectory.ts
+++ b/src/pages/directory/useDirectory.ts
@@ -8,9 +8,15 @@ import type {
     FilterKey,
     SubmitForm,
 } from "./types";
-import { API_BASE } from "./types";
+import { API_BASE, BACKEND_API_BASE } from "./types";
+import { useClient } from "../../controllers/client/ClientController";
 
 export function useDirectory() {
+    const client = useClient();
+    const sessionToken =
+        typeof client.session === "string"
+            ? client.session
+            : (client.session as any)?.token ?? "";
     const [tab, setTab] = useState<"vendors" | "resellers" | "other">(
         "vendors",
     );
@@ -43,7 +49,11 @@ export function useDirectory() {
         setLoading(true);
         setLoadError(null);
 
-        fetch(`${API_BASE}/directory/communities?limit=100`)
+        // Community listing is served by the new Rust backend (BACKEND_API_BASE)
+        // and requires auth. pageSize replaces the legacy `limit` (max 100).
+        fetch(`${BACKEND_API_BASE}/directory/communities?pageSize=100`, {
+            headers: { "x-session-token": sessionToken },
+        })
             .then((r) => r.json())
             .then((json) => {
                 if (cancelled) return;

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -15,6 +15,7 @@ import { PageHeader } from "../../components/ui/Header";
 import { useClient } from "../../controllers/client/ClientController";
 import { isTouchscreenDevice } from "../../lib/isTouchscreenDevice";
 import Promos from "./Promos";
+import { BACKEND_API_BASE } from "../directory/types";
 
 const Overlay = styled.div`
     display: grid;
@@ -337,17 +338,47 @@ const Home: React.FC = () => {
     };
 
     const fetchAndCacheData = async () => {
-        const serversUrl = import.meta.env.DEV
-            ? "/api/directory/servers"
-            : "https://manage.peptide.chat/api/directory/servers";
-        const communitiesUrl = import.meta.env.DEV
-            ? "/api/directory/communities?limit=200"
-            : "https://manageapi.peptide.chat/api/directory/communities?limit=200";
+        // Both directory endpoints are now served by the Rust backend
+        // (BACKEND_API_BASE, absolute URL — bypasses the dev `/api` proxy) and
+        // require auth via the `x-session-token` header.
+        const sessionToken =
+            typeof client.session === "string"
+                ? client.session
+                : (client.session as any)?.token ?? "";
+        const authHeaders = { "x-session-token": sessionToken };
+
+        const serversUrl = `${BACKEND_API_BASE}/directory/servers`;
+        // The backend clamps pageSize to a max of 100 and ignores the legacy
+        // `limit` param, so fetch every page to get all communities for the
+        // logo merge below (preserves the old limit=200 "fetch everything").
+        const fetchAllCommunities = async () => {
+            const first = await fetch(
+                `${BACKEND_API_BASE}/directory/communities?pageSize=100`,
+                { headers: authHeaders },
+            );
+            if (!first.ok) return [];
+            const firstJson = await first.json();
+            const items = (list: any) =>
+                Array.isArray(list) ? list : list?.items ?? [];
+            const all = items(firstJson.data);
+            const totalPages =
+                firstJson.meta?.pagination?.totalPages ?? 1;
+            for (let page = 2; page <= totalPages; page++) {
+                const res = await fetch(
+                    `${BACKEND_API_BASE}/directory/communities?pageSize=100&page=${page}`,
+                    { headers: authHeaders },
+                );
+                if (!res.ok) break;
+                const json = await res.json();
+                all.push(...items(json.data));
+            }
+            return all;
+        };
 
         try {
-            const [serversRes, communitiesRes] = await Promise.all([
-                fetch(serversUrl),
-                fetch(communitiesUrl),
+            const [serversRes, communitiesList] = await Promise.all([
+                fetch(serversUrl, { headers: authHeaders }),
+                fetchAllCommunities(),
             ]);
 
             if (!serversRes.ok) {
@@ -362,12 +393,7 @@ const Home: React.FC = () => {
             let servers: Server[] = serversJson.data;
 
             // Merge logos from communities API
-            if (communitiesRes.ok) {
-                const communitiesJson = await communitiesRes.json();
-                const communitiesList = Array.isArray(communitiesJson.data)
-                    ? communitiesJson.data
-                    : communitiesJson.data?.items ?? [];
-
+            {
                 const logoByServerId: Record<string, string> = {};
                 for (const c of communitiesList) {
                     if (c.serverId && c.logo) {

--- a/src/pages/home/PromoSubmit.tsx
+++ b/src/pages/home/PromoSubmit.tsx
@@ -9,7 +9,7 @@ import { Button, Checkbox, InputBox } from "@revoltchat/ui";
 
 import { uploadFile } from "../../controllers/client/jsx/legacy/FileUploads";
 import { useClient } from "../../controllers/client/ClientController";
-import { API_BASE } from "../directory/types";
+import { BACKEND_API_BASE } from "../directory/types";
 
 interface ItemForm {
     product: string;
@@ -256,6 +256,28 @@ interface Props {
     onClose: () => void;
 }
 
+// Map the Rust backend's Revolt-style error responses ({ type, error? }) and
+// HTTP status codes to friendly, user-facing messages.
+function promoSubmitError(status: number, body: any): string {
+    const type = body?.type;
+    if (status === 401)
+        return "Your session has expired. Please sign in again.";
+    if (status === 403 || type === "NotOwner")
+        return "You are not the owner of this server.";
+    if (status === 429)
+        return "Too many submissions. Please try again in a few minutes.";
+    if (type === "FailedValidation")
+        return (
+            body?.error ||
+            "Some fields are invalid. Please review your entries and try again."
+        );
+    if (status === 404 || type === "NotFound")
+        return "That community could not be found.";
+    return type
+        ? `Submission failed (${type}).`
+        : `Submission failed (HTTP ${status}).`;
+}
+
 const PromoSubmit = observer(({ servers, onClose }: Props) => {
     const client = useClient();
     const autumn =
@@ -472,17 +494,21 @@ const PromoSubmit = observer(({ servers, onClose }: Props) => {
 
         setState("saving");
         try {
-            const r = await fetch(`${API_BASE}/promos/submit`, {
+            // The Rust backend authenticates with `x-session-token` (not the
+            // legacy `X-Revolt-Token`) and returns HTTP 200 on success.
+            const r = await fetch(`${BACKEND_API_BASE}/promos/submit`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    "X-Revolt-Token": sessionToken,
+                    "x-session-token": sessionToken,
                 },
                 body: JSON.stringify(body),
             });
-            const res = await r.json();
+            // Some framework-level failures (e.g. a malformed body → 422)
+            // return HTML rather than JSON, so parse defensively.
+            const res = await r.json().catch(() => null);
             if (!r.ok || !res?.success) {
-                throw new Error(res?.error?.message || `HTTP ${r.status}`);
+                throw new Error(promoSubmitError(r.status, res));
             }
             setState("ok");
         } catch (err: any) {

--- a/src/pages/home/Promos.tsx
+++ b/src/pages/home/Promos.tsx
@@ -21,7 +21,7 @@ import { useEffect, useMemo, useState } from "preact/hooks";
 import { Button, InputBox, Preloader } from "@revoltchat/ui";
 
 import { useClient } from "../../controllers/client/ClientController";
-import { API_BASE } from "../directory/types";
+import { BACKEND_API_BASE } from "../directory/types";
 import ImageLightbox from "./ImageLightbox";
 import PromoSubmit from "./PromoSubmit";
 
@@ -931,7 +931,14 @@ const Promos: React.FC = () => {
                 setError(null);
             }
 
-            fetch(`${API_BASE}/promos?sort=${sort}&pageSize=100`)
+            const sessionToken =
+                typeof client.session === "string"
+                    ? client.session
+                    : (client.session as any)?.token ?? "";
+
+            fetch(`${BACKEND_API_BASE}/promos?sort=${sort}&pageSize=100`, {
+                headers: { "x-session-token": sessionToken },
+            })
                 .then((r) => r.json())
                 .then((res) => {
                     if (cancelled) return;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -116,9 +116,13 @@ export default defineConfig({
         }) as any,
     ],
     server: {
-        // Proxy the directory "manage" API in dev so /api/* requests reach the
-        // real backend instead of falling through to the SPA index.html.
-        // Production uses the absolute API_BASE (see src/pages/directory/types.ts).
+        // Proxy the legacy "manage" admin API in dev so /api/* requests reach
+        // the real backend instead of falling through to the SPA index.html.
+        // This now only serves the LEGACY endpoints that were NOT ported to the
+        // Rust backend (community reviews, submissions, single-community detail,
+        // vendor owner) — see API_BASE in src/pages/directory/types.ts.
+        // The migrated directory/promo endpoints use BACKEND_API_BASE, an
+        // absolute URL that bypasses this proxy entirely.
         proxy: {
             "/api": {
                 target: "https://manageapi.peptide.chat",


### PR DESCRIPTION
## What this does

Migrates the web client's directory + promo calls from the legacy `manage`/`manageapi` admin backend to the new Rust backend (delta), which now serves these endpoints natively and requires authentication.

`BACKEND_API_BASE` (derived from `VITE_API_URL`, already defined in `.env`/`.env.build`) is added alongside the existing legacy `API_BASE` in `src/pages/directory/types.ts`, with comments documenting which base serves what.

### Moved to the new backend (`BACKEND_API_BASE`, now with `x-session-token`)
- **Home.tsx** `fetchAndCacheData` — `GET /directory/servers` and `GET /directory/communities` (was hardcoded `manage.peptide.chat` / `manageapi.peptide.chat` URLs with a dev `/api` proxy fallback).
- **Promos.tsx** — `GET /promos?sort=&pageSize=100`.
- **PromoSubmit.tsx** — `POST /promos/submit`.
- **useDirectory.ts** — the community **listing** fetch only.

### Stayed on the legacy backend (`API_BASE`) — not ported
- **useDirectory.ts**: `GET/POST /directory/communities/reviews`, `POST /directory/communities/submissions`.
- **VendorInfo.tsx**: `GET /directory/communities/<id>` and `.../owner/<id>` (untouched, keeps `X-Revolt-Token`).

The Vite dev `/api` proxy is kept (still needed for those legacy endpoints); its comment was updated to say so. Migrated calls use absolute URLs and bypass the proxy.

## Contract changes handled
- **Auth**: every migrated request now sends `x-session-token: <session token>` (the GETs return 401 without it). Token is sourced from the Revolt client session (`(client.session as any)?.token`), the same way `PromoSubmit` already did — `useDirectory` now calls `useClient()`; `Home`/`Promos` already had the client.
- **`limit` → `pageSize`**: the backend ignores the legacy `limit` param (defaults to pageSize 50) and clamps `pageSize` to max 100. The old `limit=200` in Home is replaced with pagination: Home fetches page 1 then every remaining page (per `meta.pagination.totalPages`) so all communities are still merged for server logos. Listing/promos use `pageSize=100`.
- **Error shapes**: `PromoSubmit` now handles Revolt-style bodies (`{type}` / `{type, error}`) and maps status codes to friendly messages — 403/`NotOwner` → "You are not the owner of this server.", 429 → "Too many submissions, try again in a few minutes.", 400/`FailedValidation` → the server's `error` text, 401 → session expired, 404/`NotFound`. JSON is parsed defensively because malformed-body 422s return HTML.
- **200 vs 201**: submit success is now HTTP 200; the existing `!r.ok || !res?.success` check already accepts it.

## How it was tested
- **Build**: `yarn build:deps` + `vite build` pass cleanly (exit 0, `dist/` + service worker generated). `tsc --noEmit` has 1031 pre-existing JSX/Route type errors identical on `stage` (unrelated to this change); `eslint` has the same 4 pre-existing errors on both base and this branch — zero new errors introduced.
- **Contract (curl vs staging `https://a-pep.peptide.chat/api`)** with a real session token — every migrated URL+headers exercised:
  - `GET /directory/servers` → 401 without token; with token `{success, data:[124]}`, `showcolor: null`.
  - `GET /directory/communities?pageSize=100` → `{success, data:[100], meta.pagination{page,pageSize,total:124,totalPages:2}}`; `page=2` → 24 more. Confirmed `limit=200` is ignored (returns 50).
  - `GET /promos?sort=newest&pageSize=100` → `{success, data:{items:[16], pagination}}` with `vendor{serverId,name,logo,inviteLink}`; `GET /promos/<id>` → `{success, data:{...}}`.
  - `POST /promos/submit` → 401 no token, 403 `{"type":"NotOwner"}` on a well-formed body for an unowned server, 422 (HTML) on a malformed body. No real promo was submitted (only rejected NotOwner/validation probes).
- **Dev server**: ran `VITE_API_URL=https://a-pep.peptide.chat/api vite`; server boots, `/` returns 200 (app HTML), and all five migrated modules transform through Vite (HTTP 200) emitting the expected `BACKEND_API_BASE` + `x-session-token` + `pageSize=100`. No browser automation was available, so runtime verification was contract-level (curl) + build-level + dev-server/module-transform level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)