### PR TITLE
ci: make Docker builds actually use caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@ dist_injected
 node_modules
 .env
 .env.local
+.yarn/cache
+.yarn/install-state.gz
 
 Dockerfile
 .dockerignore

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,12 +79,7 @@ jobs:
             - name: Set up QEMU
               uses: docker/setup-qemu-action@v1
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v1
-            - name: Cache amd64 Docker layers
-              uses: actions/cache@v3
-              with:
-                  path: /tmp/.buildx-cache/linux/amd64
-                  key: ${{ runner.os }}-buildx-linux/amd64-${{ github.sha }}
+              uses: docker/setup-buildx-action@v2
             - name: Docker meta
               id: meta
               uses: docker/metadata-action@v3
@@ -104,19 +99,15 @@ jobs:
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
             - name: Build and publish
-              uses: docker/build-push-action@v2
+              uses: docker/build-push-action@v4
               with:
                   context: .
                   push: true
                   platforms: linux/amd64
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
-                  # cache-from: type=local,src=/tmp/.buildx-cache/linux/amd64
-                  # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-            # - name: Move cache
-            #   run: |
-            #       rm -rf /tmp/.buildx-cache
-            #       mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
     deploy:
         needs: [publish]
         runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,20 @@
 FROM node:16-buster AS builder
 ENV NODE_OPTIONS="--max_old_space_size=12288"
 WORKDIR /usr/src/app
+
+# Install dependencies from manifests only, so this (slowest) layer is reused
+# from cache unless the lockfile/manifests change. The portal packages
+# (external/components, external/revolt.js) only need their package.json at
+# install time — neither defines install lifecycle scripts.
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY .yarn .yarn
+COPY external/components/package.json external/components/
+COPY external/revolt.js/package.json external/revolt.js/
+RUN yarn install --frozen-lockfile
+
 COPY . .
 COPY .env.build ./.env
 
-RUN yarn install --frozen-lockfile
 RUN yarn build:deps
 # RUN yarn typecheck # lol no
 RUN yarn build:highmem


### PR DESCRIPTION
## Summary

CI builds take ~7–8 min every time because **every build re-downloads all npm dependencies** — the `YN0013: … can't be found in the cache and will be fetched from the remote registry` wall visible in any run log. Two stacked causes:

1. **Workflow**: the buildx `cache-from`/`cache-to` lines were commented out, and the leftover "Cache amd64 Docker layers" step was keyed on `github.sha` — a key unique to each commit that also was never written to. Net effect: zero layer caching. Replaced with buildx's GHA cache backend (`type=gha`), removed the dead step, bumped `setup-buildx-action` v1→v2 and `build-push-action` v2→v4 (same combo the backend repo uses with `type=gha`).

2. **Dockerfile**: `COPY . .` ran *before* `yarn install`, so even working layer caching would be invalidated by any source edit. Dependencies now install from manifests only (`package.json`, `yarn.lock`, `.yarnrc.yml`, `.yarn` tooling, plus the two portal packages' `package.json` — `external/components` and `external/revolt.js` have no install lifecycle scripts, so manifests suffice), then the full source is copied for the build steps.

Also added `.yarn/cache` / `.yarn/install-state.gz` to `.dockerignore` (gitignored anyway, but keeps local `docker build` contexts small and layer checksums stable).

## Verification

- Simulated the new install layer exactly: a clean directory containing only the copied manifest set completes `yarn install --frozen-lockfile` successfully.
- The docker workflow doesn't run on PRs to stage, so the first cached run happens post-merge: expect the merge commit's run to be a cold build (populates the GHA cache) and the *next* source-only push to skip the install layer entirely (no YN0013 wall, ~2–3 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)