### PR TITLE
fix: remove Google Sheet fallback and handle missing directory/promo …

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
         "fs-extra": "^10.0.0",
         "klaw": "^3.0.0",
         "lottie-react": "^2.4.0",
-        "papaparse": "^5.4.1",
         "sirv-cli": "^1.0.14",
         "vite": "^3.0.5"
     },
@@ -97,7 +96,6 @@
         "@types/lodash.defaultsdeep": "^4.6.6",
         "@types/lodash.isequal": "^4.5.5",
         "@types/node": "^15.14.9",
-        "@types/papaparse": "^5.3.15",
         "@types/preact-i18n": "^2.3.0",
         "@types/prismjs": "^1.26.0",
         "@types/react-beautiful-dnd": "^13",

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,7 +1,6 @@
 import { Search, X } from "@styled-icons/boxicons-regular";
 import { Lock, MessageAdd } from "@styled-icons/boxicons-solid";
 import { observer } from "mobx-react-lite";
-import Papa from "papaparse";
 import React, { useEffect, useMemo, useState } from "react";
 import { Link, useHistory, useLocation } from "react-router-dom";
 import styled from "styled-components/macro";
@@ -78,10 +77,26 @@ const ColorWrapper = styled.div<{ color: string }>`
     }
 `;
 
-function ServerIcon({ logo, size }: { logo: string; size: number }) {
+// Logo ids can reference files missing from this environment's autumn (e.g.
+// staging seeded from prod data), so a failed load falls back to the state
+// glyph instead of a broken image.
+function ServerIcon({
+    logo,
+    size,
+    fallback,
+}: {
+    logo: string;
+    size: number;
+    fallback: React.ReactNode;
+}) {
+    const [failed, setFailed] = useState(false);
+
+    if (failed) return <>{fallback}</>;
+
     return (
         <img
             src={logo}
+            onError={() => setFailed(true)}
             style={{
                 width: size,
                 height: size,
@@ -305,38 +320,6 @@ const Home: React.FC = () => {
         setLoading(false);
     };
 
-    // Fallback: load the server list from the published Google Sheets CSV.
-    const fetchFromSheet = () => {
-        const csvUrl =
-            "https://docs.google.com/spreadsheets/d/e/2PACX-1vRY41D-NgTE6bC3kTN3dRpisI-DoeHG8Eg7n31xb1CdydWjOLaphqYckkTiaG9oIQSWP92h3NE-7cpF/pub?gid=0&single=true&output=csv";
-
-        // Add cache-busting parameter to prevent browser caching
-        const urlWithCacheBust = `${csvUrl}&_cb=${Date.now()}`;
-
-        Papa.parse<Server>(urlWithCacheBust, {
-            download: true,
-            header: true,
-            dynamicTyping: true,
-            complete: (result) => {
-                if (result.errors.length > 0) {
-                    console.error("CSV parsing errors:", result.errors);
-                    setError("Error parsing server data");
-                    setLoading(false);
-                    return;
-                }
-
-                cacheAndSetServers(result.data);
-            },
-            error: (err) => {
-                console.error("Error fetching CSV:", err);
-                setError(
-                    "Failed to load server data. Please try again later.",
-                );
-                setLoading(false);
-            },
-        });
-    };
-
     const fetchAndCacheData = async () => {
         // Both directory endpoints are now served by the Rust backend
         // (BACKEND_API_BASE, absolute URL — bypasses the dev `/api` proxy) and
@@ -415,8 +398,9 @@ const Home: React.FC = () => {
 
             cacheAndSetServers(servers);
         } catch (err) {
-            console.warn("Server list API failed, falling back to CSV:", err);
-            fetchFromSheet();
+            console.error("Failed to load the community directory:", err);
+            setError("Failed to load communities. Please try again later.");
+            setLoading(false);
         }
     };
 
@@ -467,12 +451,16 @@ const Home: React.FC = () => {
                 isServerJoined.generateIconURL({ max_side: 256 }) ?? undefined;
         }
 
-        const avatar = avatarUrl ? (
-            <ServerIcon logo={avatarUrl} size={32} />
-        ) : server.disabled ? (
+        const fallbackGlyph = server.disabled ? (
             <Lock size={32} />
         ) : (
             <MessageAdd size={32} />
+        );
+
+        const avatar = avatarUrl ? (
+            <ServerIcon logo={avatarUrl} size={32} fallback={fallbackGlyph} />
+        ) : (
+            fallbackGlyph
         );
 
         // Keep the logo for locked servers, but mark it with a corner lock badge.

--- a/src/pages/home/Promos.tsx
+++ b/src/pages/home/Promos.tsx
@@ -637,6 +637,10 @@ const PromoCard = observer(
     }) => {
     const client = useClient();
     const [expanded, setExpanded] = useState(false);
+    // Vendor logo ids can reference files missing from this environment's
+    // autumn (e.g. staging seeded from prod data), so a failed load falls
+    // back to the store glyph instead of a broken image.
+    const [logoFailed, setLogoFailed] = useState(false);
     const autumn =
         client.configuration?.features.autumn?.url ||
         "https://peptide.chat/autumn";
@@ -665,8 +669,12 @@ const PromoCard = observer(
     return (
         <Card>
             <CardHead>
-                {logoUrl ? (
-                    <Logo src={logoUrl} loading="lazy" />
+                {logoUrl && !logoFailed ? (
+                    <Logo
+                        src={logoUrl}
+                        loading="lazy"
+                        onError={() => setLogoFailed(true)}
+                    />
                 ) : (
                     <LogoFallback>
                         <Store size={22} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2855,15 +2855,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/papaparse@npm:^5.3.15":
-  version: 5.3.15
-  resolution: "@types/papaparse@npm:5.3.15"
-  dependencies:
-    "@types/node": "*"
-  checksum: 265cc2fd7e36514568398491a9b1d47ad4408f3946fd19f69202ef7af313c8d094ef1562172a36bec6e34ae8e9daf80fc1c5a36327858c236c50c6ebaac3e221
-  languageName: node
-  linkType: hard
-
 "@types/parse-json@npm:^4.0.0":
   version: 4.0.0
   resolution: "@types/parse-json@npm:4.0.0"
@@ -3886,7 +3877,6 @@ __metadata:
     "@types/lodash.defaultsdeep": ^4.6.6
     "@types/lodash.isequal": ^4.5.5
     "@types/node": ^15.14.9
-    "@types/papaparse": ^5.3.15
     "@types/preact-i18n": ^2.3.0
     "@types/prismjs": ^1.26.0
     "@types/react-beautiful-dnd": ^13
@@ -3923,7 +3913,6 @@ __metadata:
     mediasoup-client: "npm:@insertish/mediasoup-client@3.6.36-esnext"
     mobx: ^6.6.0
     mobx-react-lite: 3.4.0
-    papaparse: ^5.4.1
     preact: ^10.5.14
     preact-context-menu: 0.4.1
     preact-i18n: ^2.4.0-preactx
@@ -7678,13 +7667,6 @@ __metadata:
   dependencies:
     aggregate-error: ^3.0.0
   checksum: cb0ab21ec0f32ddffd31dfc250e3afa61e103ef43d957cc45497afe37513634589316de4eb88abdfd969fe6410c22c0b93ab24328833b8eb1ccc087fc0442a1c
-  languageName: node
-  linkType: hard
-
-"papaparse@npm:^5.4.1":
-  version: 5.4.1
-  resolution: "papaparse@npm:5.4.1"
-  checksum: fc9e52f7158dca3517c229e3309065b1ab5da6c7194572fba4f31ff138bc43e3c91182cc40365cc828f97fe10d0aca416068fd731661058bea0f69ddb84a411a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
…logos

The community directory now relies solely on the backend API: on failure it surfaces an error instead of silently loading a stale Google Sheets CSV (papaparse dependency dropped with it).

Directory and promo vendor logos fall back to their state/store glyph when the icon file 404s — staging autumn doesn't have the icon files referenced by data seeded from prod, which rendered as broken images.

## Please make sure to check the following tasks before opening and submitting a PR

* [ ] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [ ] I have tested my changes locally and they are working as intended
* [ ] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [ ] I have included screenshots to demonstrate my changes
