### PR TITLE
fix(serve): stop browsers caching index.html across releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
         "lint": "eslint src/**/*.{js,jsx,ts,tsx}",
         "fmt": "prettier --write 'src/**/*.{js,jsx,ts,tsx}'",
         "typecheck": "tsc --noEmit",
-        "start": "sirv dist --cors --single --host",
-        "start:inject": "node scripts/inject.js && sirv dist_injected --cors --single --host"
+        "start": "node scripts/serve.js dist",
+        "start:inject": "node scripts/inject.js && node scripts/serve.js dist_injected"
     },
     "eslintConfig": {
         "parser": "@typescript-eslint/parser",

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -1,0 +1,51 @@
+/* eslint-disable */
+/**
+ * Static file server replacing `sirv-cli` so cache headers can differ per
+ * path — sirv-cli only supports a single global Cache-Control.
+ *
+ * Why this matters: each release ships a fresh set of hash-named files under
+ * /assets and deletes the previous ones. Without an explicit Cache-Control,
+ * browsers heuristically cache index.html (10% of its Last-Modified age), so
+ * after a deploy clients keep loading a stale index.html whose asset hashes
+ * no longer exist — white screen until a hard refresh.
+ *
+ *   - HTML / everything unhashed (/, /sw.js, manifest): no-cache, i.e.
+ *     revalidate with the server on every load.
+ *   - /assets/<name>.<hash>.<ext>: immutable for a year — a given URL's
+ *     content never changes, only the URL does.
+ *
+ * `sirv` is a dependency of `sirv-cli` (a production dependency), so it is
+ * always present in the pruned production node_modules.
+ */
+const http = require("http");
+const sirv = require("sirv");
+
+const dir = process.argv[2] || "dist";
+const port = Number(process.env.PORT) || 5000;
+
+const serve = sirv(dir, {
+    single: true, // SPA fallback to index.html, like `sirv --single`
+    etag: true,
+    setHeaders(res, pathname) {
+        if (pathname.startsWith("/assets/")) {
+            res.setHeader(
+                "Cache-Control",
+                "public, max-age=31536000, immutable",
+            );
+        } else {
+            res.setHeader("Cache-Control", "no-cache");
+        }
+    },
+});
+
+http.createServer((req, res) => {
+    // parity with `sirv --cors`
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader(
+        "Access-Control-Allow-Headers",
+        "Origin, Content-Type, Accept, Range",
+    );
+    serve(req, res);
+}).listen(port, "0.0.0.0", () => {
+    console.log(`Serving ${dir} on 0.0.0.0:${port}`);
+});


### PR DESCRIPTION
## Why

After every release the site goes blank for returning users with a console error about a missing hashed asset. Root cause (verified against the live site): `sirv-cli` sends **no Cache-Control header**, so browsers apply heuristic caching to `index.html` (10% of its Last-Modified age — hours). After a deploy, clients keep loading the stale `index.html`, whose `/assets/*.<hash>.js` files no longer exist in the new image → white screen until hard refresh.

Live headers before this fix: `/` has no `cache-control` at all; assets get CF's default `max-age=14400`.

## What

Replace `sirv-cli` with a ~40-line server using the `sirv` middleware (ships inside `sirv-cli`, which is already a production dependency — no lockfile change):

- `index.html` / `sw.js` / anything unhashed → `Cache-Control: no-cache` (always revalidate)
- `/assets/*` (content-hashed) → `public, max-age=31536000, immutable`

Same CORS/single/host/port behavior as the old `sirv` flags.

## Verification

Smoke-tested against a real `dist`: `/` and SPA fallback return `no-cache`, hashed assets return `immutable`, missing assets 404 (no SPA fallback masking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4WJUaEacQbC2DP1iRMX8v