### PR TITLE
fix(ci): restore master/pre-production in Docker workflow triggers

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,8 @@ name: Docker
 on:
     push:
         branches:
-
+            - "master"
+            - "pre-production"
             - "stage"
         tags:
             - "*"


### PR DESCRIPTION
The stage CI-cache commit (#78) narrowed the Docker workflow's push trigger to `stage` only. Promoting stage → master (#82) carried that along, which **silently disabled all master deploys** — #82 merged but no build ran, so the API migration isn't live yet.

Restores `master` + `pre-production` (and keeps `stage`) in the trigger list. Merging this PR will itself trigger the master build, deploying #82's changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4WJUaEacQbC2DP1iRMX8v