### PR TITLE
fix(ci): master builds must publish revolt-revite-pre and pin the prod config

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,7 +85,7 @@ jobs:
               id: meta
               uses: docker/metadata-action@v3
               with:
-                  images: ghcr.io/archem-team/revolt-revite-stage
+                  images: ghcr.io/archem-team/revolt-revite-pre
                   tags: |
                     type=raw,value=${{ github.sha }}
             # - name: Login to DockerHub
@@ -113,7 +113,7 @@ jobs:
         needs: [publish]
         runs-on: ubuntu-latest
         env:
-          CONFIG_BRANCH: stage
+          CONFIG_BRANCH: prod
           CLONE_DIR: $GITHUB_WORKSPACE/config
           CONFIG_FILE: $GITHUB_WORKSPACE/config/apps/pepchat/kustomization.yaml
         if: github.event_name != 'pull_request'
@@ -140,7 +140,7 @@ jobs:
               run: |
                   awk -v value="  newTag: ${{ github.sha }}" '{sub(/^  newTag: .*/, value); print}' $CONFIG_FILE > temp.yml && mv temp.yml $CONFIG_FILE
 
-                  awk -v value="  newName: ghcr.io/archem-team/revolt-revite-stage" '{sub(/^  newName: .*/, value); print}' $CONFIG_FILE > temp.yml && mv temp.yml $CONFIG_FILE
+                  awk -v value="  newName: ghcr.io/archem-team/revolt-revite-pre" '{sub(/^  newName: .*/, value); print}' $CONFIG_FILE > temp.yml && mv temp.yml $CONFIG_FILE
 
 
             - name: Commit & Push Changes


### PR DESCRIPTION
Second and final stage-ism from the #82 promotion: master's docker.yml was publishing to the `revolt-revite-stage` image and pinning the administration-cluster **stage** branch — so the previous master build deployed a prod-configured client onto the *stage* cluster and never touched prod.

Restores the pre-merge master publish targets:
- `images: ghcr.io/archem-team/revolt-revite-pre`
- `CONFIG_BRANCH: prod` + matching `newName`

Merging this triggers the master build that actually deploys #82 (API migration) to the live site.

Note: the stage config pin still needs a manual revert to `aa424da8` (its last real stage build) — flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4WJUaEacQbC2DP1iRMX8v