### PR TITLE
ci: derive deploy targets from branch name

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -81,11 +81,16 @@ jobs:
               uses: docker/setup-qemu-action@v1
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v2
+            # Branch-aware deploy targets so this file is identical on every
+            # branch: master/pre-production -> "-pre" image + prod config,
+            # anything else (stage) -> "-stage" image + stage config. A
+            # stage<->master merge of this file must never change where a
+            # branch deploys.
             - name: Docker meta
               id: meta
               uses: docker/metadata-action@v3
               with:
-                  images: ghcr.io/archem-team/revolt-revite-pre
+                  images: ghcr.io/archem-team/revolt-revite-${{ (github.ref_name == 'master' || github.ref_name == 'pre-production') && 'pre' || 'stage' }}
                   tags: |
                     type=raw,value=${{ github.sha }}
             # - name: Login to DockerHub
@@ -113,10 +118,12 @@ jobs:
         needs: [publish]
         runs-on: ubuntu-latest
         env:
-          CONFIG_BRANCH: prod
+          CONFIG_BRANCH: ${{ (github.ref_name == 'master' || github.ref_name == 'pre-production') && 'prod' || 'stage' }}
+          IMAGE_NAME: ghcr.io/archem-team/revolt-revite-${{ (github.ref_name == 'master' || github.ref_name == 'pre-production') && 'pre' || 'stage' }}
           CLONE_DIR: $GITHUB_WORKSPACE/config
           CONFIG_FILE: $GITHUB_WORKSPACE/config/apps/pepchat/kustomization.yaml
-        if: github.event_name != 'pull_request'
+        # ref_type guard: only branch pushes may re-pin an environment
+        if: github.event_name != 'pull_request' && github.ref_type == 'branch'
         steps:
             - name: Set up deploy key
               run: |
@@ -140,7 +147,7 @@ jobs:
               run: |
                   awk -v value="  newTag: ${{ github.sha }}" '{sub(/^  newTag: .*/, value); print}' $CONFIG_FILE > temp.yml && mv temp.yml $CONFIG_FILE
 
-                  awk -v value="  newName: ghcr.io/archem-team/revolt-revite-pre" '{sub(/^  newName: .*/, value); print}' $CONFIG_FILE > temp.yml && mv temp.yml $CONFIG_FILE
+                  awk -v value="  newName: $IMAGE_NAME" '{sub(/^  newName: .*/, value); print}' $CONFIG_FILE > temp.yml && mv temp.yml $CONFIG_FILE
 
 
             - name: Commit & Push Changes


### PR DESCRIPTION
Root-cause fix for today's deploy mixups: image repo and administration-cluster config branch are now computed from `github.ref_name` (master/pre-production → `revolt-revite-pre` + `prod`; anything else → `revolt-revite-stage` + `stage`), so `docker.yml` is byte-identical on every branch and a stage↔master merge can never retarget deploys again. Also gates the config-pin job to branch pushes only (tags build but never re-pin).

Same commit will be cherry-picked to `stage` so the files match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4WJUaEacQbC2DP1iRMX8v