### PR TITLE
feat(directory,promo): numeric guarantee % + prefill promo form (production)

### DIFF
--- a/src/pages/directory/CommunityCard.tsx
+++ b/src/pages/directory/CommunityCard.tsx
@@ -266,14 +266,14 @@ export function CommunityCard({
                         {c.freeShipping && (
                             <InfoLine>
                                 <Badge $v="green">Free Shipping</Badge>
-                                {c.freeShippingThreshold && (
+                                {c.freeShippingThreshold != null && (
                                     <span
                                         style={{
                                             fontSize: "var(--font-size-caption-1)",
                                             marginLeft: "var(--space-2)",
                                             color: "var(--tertiary-foreground)",
                                         }}>
-                                        over {c.freeShippingThreshold}
+                                        over ${c.freeShippingThreshold}
                                     </span>
                                 )}
                             </InfoLine>
@@ -337,7 +337,7 @@ export function CommunityRow({
                     {isReseller && <td>{c.orderTypes ? <OrderBadges orderTypes={c.orderTypes} /> : <span style={{ color: "var(--tertiary-foreground)" }}>—</span>}</td>}
                     <td>
                         {c.freeShipping
-                            ? <Badge $v="green">✓ {c.freeShippingThreshold || "Yes"}</Badge>
+                            ? <Badge $v="green">✓ {c.freeShippingThreshold != null ? `$${c.freeShippingThreshold}` : "Yes"}</Badge>
                             : <span style={{ color: "var(--tertiary-foreground)" }}>—</span>}
                     </td>
                     <td style={{ whiteSpace: "nowrap", color: "var(--color-text-primary)" }}>{c.shippingTime}</td>

--- a/src/pages/directory/dataUtils.ts
+++ b/src/pages/directory/dataUtils.ts
@@ -11,6 +11,7 @@ import type {
     Products,
     Guarantees,
     GuaranteeTexts,
+    GuaranteePct,
     OrderTypes,
     FilterKey,
 } from "./types";
@@ -136,16 +137,28 @@ export function apiToCommunity(c: any): Community {
         custom: Array.isArray(apiPr.custom) ? apiPr.custom : [],
     };
 
-    // Guarantees — backend may use purityDesc/volumeDesc/reshipDesc as text keys
+    // Guarantees — purity/volume are numeric percentages; reship stays text
     const apiGu = c.guarantee ?? c.guarantees ?? {};
     const guarantees: Guarantees = {
         purity: apiGu.purity ?? false,
         volume: apiGu.volume ?? false,
         reship: apiGu.reship ?? false,
     };
+    const guaranteePct: GuaranteePct = {
+        purity: typeof apiGu.purityPct === "number" ? apiGu.purityPct : null,
+        volume: typeof apiGu.volumePct === "number" ? apiGu.volumePct : null,
+    };
+    // Derive display hints from the numeric percentages so existing badge
+    // tooltips keep working; reship keeps its free-text note.
     const guaranteeTexts = mapGuaranteeTexts({
-        purity: apiGu.purityDesc ?? c.guaranteeTexts?.purity,
-        volume: apiGu.volumeDesc ?? c.guaranteeTexts?.volume,
+        purity:
+            guaranteePct.purity != null
+                ? `≥ ${guaranteePct.purity}% purity`
+                : undefined,
+        volume:
+            guaranteePct.volume != null
+                ? `≥ ${guaranteePct.volume}% fill volume`
+                : undefined,
         reship: apiGu.reshipDesc ?? c.guaranteeTexts?.reship,
     });
 
@@ -156,9 +169,13 @@ export function apiToCommunity(c: any): Community {
         products,
         guarantees,
         guaranteeTexts,
+        guaranteePct,
         shippingTime: c.shippingTime || "",
         freeShipping: c.freeShipping || false,
-        freeShippingThreshold: c.freeShippingThreshold || "",
+        freeShippingThreshold:
+            typeof c.freeShippingThreshold === "number"
+                ? c.freeShippingThreshold
+                : null,
     };
     if (c.type === "reseller") {
         return {

--- a/src/pages/directory/types.ts
+++ b/src/pages/directory/types.ts
@@ -32,7 +32,15 @@ export interface Guarantees {
     volume: boolean;
     reship: boolean;
 }
+// Display hints per guarantee. purity/volume are derived from the numeric
+// percentages (see GuaranteePct); reship carries the free-text note.
 export type GuaranteeTexts = Record<keyof Guarantees, string>;
+// Numeric guarantee percentages (0-100), the stored source of truth for
+// purity/volume. Null when the vendor offers the guarantee without a figure.
+export interface GuaranteePct {
+    purity: number | null;
+    volume: number | null;
+}
 export interface OrderTypes {
     single: boolean;
     halfkit: boolean;
@@ -64,10 +72,11 @@ export interface VendorCommunity extends CommunityBase {
     products: Products;
     guarantees: Guarantees;
     guaranteeTexts?: GuaranteeTexts;
+    guaranteePct: GuaranteePct;
     orderTypes: null;
     shippingTime: string;
     freeShipping: boolean;
-    freeShippingThreshold: string;
+    freeShippingThreshold: number | null;
 }
 
 export interface ResellerCommunity extends CommunityBase {
@@ -77,10 +86,11 @@ export interface ResellerCommunity extends CommunityBase {
     products: Products;
     guarantees: Guarantees;
     guaranteeTexts?: GuaranteeTexts;
+    guaranteePct: GuaranteePct;
     orderTypes: OrderTypes;
     shippingTime: string;
     freeShipping: boolean;
-    freeShippingThreshold: string;
+    freeShippingThreshold: number | null;
 }
 
 export interface OtherCommunity extends CommunityBase {

--- a/src/pages/home/PromoSubmit.tsx
+++ b/src/pages/home/PromoSubmit.tsx
@@ -3,13 +3,13 @@ import { observer } from "mobx-react-lite";
 import { Server } from "revolt.js";
 import styled from "styled-components/macro";
 
-import { useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 
 import { Button, Checkbox, InputBox } from "@revoltchat/ui";
 
 import { uploadFile } from "../../controllers/client/jsx/legacy/FileUploads";
 import { useClient } from "../../controllers/client/ClientController";
-import { BACKEND_API_BASE } from "../directory/types";
+import { API_BASE, BACKEND_API_BASE, WAREHOUSE_LABELS } from "../directory/types";
 
 interface ItemForm {
     product: string;
@@ -316,6 +316,52 @@ const PromoSubmit = observer(({ servers, onClose }: Props) => {
         typeof client.session === "string"
             ? client.session
             : (client.session as any)?.token ?? "";
+
+    // Prefill the vendor's non-changing commerce details from their directory
+    // listing (warehouse, shipping, guarantee) so they don't retype them each
+    // submission. Runs when the selected community changes; the offer-specific
+    // fields (products, prices, dates, title) stay empty for the vendor to fill.
+    useEffect(() => {
+        if (!serverId) return;
+        let ignore = false;
+        (async () => {
+            try {
+                const r = await fetch(
+                    `${API_BASE}/directory/communities/${serverId}`,
+                );
+                if (!r.ok) return;
+                const res = await r.json();
+                const c = res?.data ?? res;
+                if (ignore || !c?.id) return;
+
+                const wh = c.warehouses ?? {};
+                const warehouseStr = (
+                    Object.keys(WAREHOUSE_LABELS) as (keyof typeof WAREHOUSE_LABELS)[]
+                )
+                    .filter((k) => wh[k])
+                    .map((k) => WAREHOUSE_LABELS[k])
+                    .join(", ");
+                if (warehouseStr) setWarehouse(warehouseStr);
+
+                if (c.shippingTime) setShippingNote(c.shippingTime);
+                if (typeof c.freeShippingThreshold === "number")
+                    setFreeShippingThreshold(String(c.freeShippingThreshold));
+
+                const g = c.guarantee ?? {};
+                if (typeof g.purityPct === "number")
+                    setPurityPct(String(g.purityPct));
+                if (typeof g.volumePct === "number")
+                    setVolumePct(String(g.volumePct));
+                if (g.reship) setCustomsReship(true);
+                if (g.reshipDesc) setGuaranteeText(g.reshipDesc);
+            } catch {
+                // Prefill is best-effort; ignore fetch/parse failures.
+            }
+        })();
+        return () => {
+            ignore = true;
+        };
+    }, [serverId]);
 
     const setItem = (i: number, patch: Partial<ItemForm>) => {
         setItems((prev) =>

--- a/src/pages/settings/server/VendorInfo.tsx
+++ b/src/pages/settings/server/VendorInfo.tsx
@@ -3,20 +3,23 @@ import { Server } from "revolt.js";
 import { useEffect, useState } from "preact/hooks";
 import { useClient } from "../../../controllers/client/ClientController";
 import {
-    defPay, defWh, defPr, defGu, defGuText, defOr, toggle,
+    defPay, defWh, defPr, defGu, defOr, toggle,
 } from "../../directory/dataUtils";
 import {
     PAYMENT_LABELS, WAREHOUSE_LABELS, PRODUCT_LABELS,
     GUARANTEE_LABELS, ORDER_LABELS, API_BASE,
 } from "../../directory/types";
-import type { Payment, Warehouses, Products, Guarantees, GuaranteeTexts, OrderTypes } from "../../directory/types";
+import type { Payment, Warehouses, Products, Guarantees, OrderTypes } from "../../directory/types";
 
 interface VendorData {
     payment: Payment;
     warehouses: Warehouses;
     products: Products;
     guarantees: Guarantees;
-    guaranteeTexts: GuaranteeTexts;
+    // purity/volume are numeric percentages (held as form strings); reship note
+    purityPct: string;
+    volumePct: string;
+    reshipText: string;
     orderTypes: OrderTypes;
     shippingTime: string;
     freeShipping: boolean;
@@ -28,12 +31,16 @@ const defaultData = (): VendorData => ({
     warehouses: { ...defWh },
     products: { ...defPr },
     guarantees: { ...defGu },
-    guaranteeTexts: { ...defGuText },
+    purityPct: "",
+    volumePct: "",
+    reshipText: "",
     orderTypes: { ...defOr },
     shippingTime: "",
     freeShipping: false,
     freeShippingThreshold: "",
 });
+
+const numToStr = (v: unknown) => (typeof v === "number" ? String(v) : "");
 
 function apiToData(c: any): VendorData {
     const apiGu = c.guarantee ?? {};
@@ -46,15 +53,13 @@ function apiToData(c: any): VendorData {
             volume: apiGu.volume ?? false,
             reship: apiGu.reship ?? false,
         },
-        guaranteeTexts: {
-            purity: apiGu.purityDesc ?? defGuText.purity,
-            volume: apiGu.volumeDesc ?? defGuText.volume,
-            reship: apiGu.reshipDesc ?? defGuText.reship,
-        },
+        purityPct: numToStr(apiGu.purityPct),
+        volumePct: numToStr(apiGu.volumePct),
+        reshipText: apiGu.reshipDesc ?? "",
         orderTypes: { ...defOr, ...(c.orderTypes ?? {}) },
         shippingTime: c.shippingTime ?? "",
         freeShipping: c.freeShipping ?? false,
-        freeShippingThreshold: c.freeShippingThreshold ?? "",
+        freeShippingThreshold: numToStr(c.freeShippingThreshold),
     };
 }
 
@@ -64,14 +69,14 @@ function buildPayload(form: VendorData, isReseller: boolean) {
         warehouses: form.warehouses,
         products: form.products,
         guarantee: {
-            purity: form.guarantees.purity, purityDesc: form.guaranteeTexts.purity,
-            volume: form.guarantees.volume, volumeDesc: form.guaranteeTexts.volume,
-            reship: form.guarantees.reship, reshipDesc: form.guaranteeTexts.reship,
+            purity: form.guarantees.purity, purityPct: form.purityPct ? Number(form.purityPct) : null,
+            volume: form.guarantees.volume, volumePct: form.volumePct ? Number(form.volumePct) : null,
+            reship: form.guarantees.reship, reshipDesc: form.reshipText,
         },
         orderTypes: isReseller ? form.orderTypes : undefined,
         shippingTime: form.shippingTime || undefined,
         freeShipping: form.freeShipping,
-        freeShippingThreshold: form.freeShippingThreshold || undefined,
+        freeShippingThreshold: form.freeShippingThreshold ? Number(form.freeShippingThreshold) : undefined,
     };
 }
 
@@ -214,10 +219,14 @@ export const VendorInfo = observer(({ server }: Props) => {
 
                 <div style={S.divider} />
 
-                {/* Guarantees */}
+                {/* Guarantees — purity/volume are numeric %, reship is a note */}
                 <div style={S.section}>
                     <div style={S.label}>Guarantees</div>
-                    {(["purity", "volume", "reship"] as const).map((k) => (
+                    {([
+                        { k: "purity", field: "purityPct", numeric: true },
+                        { k: "volume", field: "volumePct", numeric: true },
+                        { k: "reship", field: "reshipText", numeric: false },
+                    ] as const).map(({ k, field, numeric }) => (
                         <div key={k} style={{ marginBottom: "12px" }}>
                             <label style={S.checkItem(form.guarantees[k])}>
                                 <input type="checkbox" style={{ display: "none" }} checked={form.guarantees[k]}
@@ -225,10 +234,13 @@ export const VendorInfo = observer(({ server }: Props) => {
                                 {GUARANTEE_LABELS[k]}
                             </label>
                             <input
-                                type="text"
+                                type={numeric ? "number" : "text"}
+                                min={numeric ? 0 : undefined}
+                                max={numeric ? 100 : undefined}
+                                placeholder={numeric ? "% e.g. 99" : "e.g. reship if seized by customs"}
                                 style={{ ...S.input, marginTop: "4px", fontSize: "12px" }}
-                                value={form.guaranteeTexts[k]}
-                                onInput={(e) => setForm((f) => ({ ...f, guaranteeTexts: { ...f.guaranteeTexts, [k]: (e.target as HTMLInputElement).value } }))}
+                                value={form[field]}
+                                onInput={(e) => setForm((f) => ({ ...f, [field]: (e.target as HTMLInputElement).value }))}
                             />
                         </div>
                     ))}
@@ -243,7 +255,7 @@ export const VendorInfo = observer(({ server }: Props) => {
                         <input type="text" style={S.input} placeholder="Shipping time e.g. 3-5 days"
                             value={form.shippingTime}
                             onInput={(e) => setForm((f) => ({ ...f, shippingTime: (e.target as HTMLInputElement).value }))} />
-                        <input type="text" style={S.input} placeholder="Free shipping threshold e.g. $150"
+                        <input type="number" min={0} style={S.input} placeholder="Free shipping threshold e.g. 150"
                             value={form.freeShippingThreshold}
                             onInput={(e) => setForm((f) => ({ ...f, freeShippingThreshold: (e.target as HTMLInputElement).value }))} />
                     </div>


### PR DESCRIPTION
## What
Numeric guarantee %/free-shipping threshold on the directory model + **prefill the promo submission form** from the vendor's directory listing. Same change verified on stage (#90).

- Directory types/mapper: `guaranteePct` (numeric purity/volume), numeric `freeShippingThreshold`; badge tooltips derive from the numbers so display is unchanged.
- `VendorInfo` (owner edit): numeric % inputs + numeric threshold.
- `PromoSubmit`: on community change, prefills warehouse / shipping note / free-shipping threshold / guarantee (purity%, volume%, customs reship, note) from `GET /directory/communities/<id>`.

## Release ordering
Depends on the legacy-admin numeric API (already on `main`) + the prod `directory_servers` migration being applied, so the fetched listing carries numeric fields. Merge after backend production PR (#46) is deployed and prod Mongo migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1sXZS8qjcTssn733GdSCQ