### PR TITLE
feat(catalog): Compound Finder marketplace tab + catalog CRUD settings

### DIFF
--- a/src/pages/home/Catalog.tsx
+++ b/src/pages/home/Catalog.tsx
@@ -1,0 +1,316 @@
+import { Search, X, Store, SortAlt } from "@styled-icons/boxicons-regular";
+import { BadgeCheck } from "@styled-icons/boxicons-solid";
+import { observer } from "mobx-react-lite";
+import { Link } from "react-router-dom";
+import styled from "styled-components/macro";
+import { useEffect, useMemo, useState } from "preact/hooks";
+import { InputBox, Preloader } from "@revoltchat/ui";
+import { useClient } from "../../controllers/client/ClientController";
+import { BACKEND_API_BASE } from "../directory/types";
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+interface CatalogItem {
+    id: string;
+    serverId?: string | null;
+    vendorName?: string | null;
+    product: string;
+    normalized?: string | null;
+    fromPrice: number;
+    toPrice?: number | null;
+    currency: string;
+    categories: string[];
+    createdAt: string;
+}
+
+interface CatalogResponse {
+    success: boolean;
+    data: {
+        items: CatalogItem[];
+        pagination: { page: number; pageSize: number; total: number; totalPages: number };
+    };
+}
+
+interface VendorInfo {
+    serverId: string;
+    name: string;
+    logo?: string | null;
+    inviteLink?: string | null;
+    productCount: number;
+    categories: string[];
+}
+
+interface CategoryInfo {
+    category: string;
+    count: number;
+    vendorCount: number;
+}
+
+// ─── Styled Components ────────────────────────────────────────────────
+
+const PageWrap = styled.div`
+    padding: 0 16px 32px;
+    max-width: 1200px;
+    margin: 0 auto;
+`;
+
+const SearchRow = styled.div`
+    display: flex;
+    gap: 12px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+    align-items: center;
+`;
+
+const SearchField = styled.div`
+    position: relative;
+    flex: 1;
+    min-width: 200px;
+    input { padding-left: 38px; padding-right: 32px; }
+    .icon { position: absolute; left: 10px; top: 50%; transform: translateY(-50%); color: var(--tertiary-foreground); }
+    .clear { position: absolute; right: 8px; top: 50%; transform: translateY(-50%); cursor: pointer; color: var(--tertiary-foreground); display: flex; }
+`;
+
+const SortSelect = styled.select`
+    padding: 8px 12px; border-radius: 6px; border: 1px solid var(--tertiary-foreground);
+    background: var(--secondary-background); color: var(--foreground); font-size: 13px; cursor: pointer;
+`;
+
+const Layout = styled.div`
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    gap: 24px;
+    @media (max-width: 768px) { grid-template-columns: 1fr; }
+`;
+
+const Sidebar = styled.div`
+    @media (max-width: 768px) { display: none; }
+`;
+
+const SidebarTitle = styled.div`
+    font-size: 13px; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 0.06em; color: var(--secondary-foreground); margin-bottom: 12px;
+`;
+
+const CategoryChip = styled.div<{ active: boolean }>`
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 8px 12px; border-radius: 6px; cursor: pointer; font-size: 13px; margin-bottom: 4px;
+    background: ${p => p.active ? "var(--accent)" : "var(--secondary-background)"};
+    color: ${p => p.active ? "white" : "var(--foreground)"};
+    transition: background 0.15s;
+    &:hover { background: ${p => p.active ? "var(--accent)" : "var(--tertiary-background)"}; }
+    span { font-size: 11px; color: ${p => p.active ? "rgba(255,255,255,0.7)" : "var(--tertiary-foreground)"}; }
+`;
+
+const PriceFilter = styled.div`
+    display: flex; gap: 8px; margin-bottom: 16px;
+    input { width: 100%; padding: 6px 8px; border-radius: 6px; border: 1px solid var(--tertiary-foreground);
+        background: var(--secondary-background); color: var(--foreground); font-size: 12px; box-sizing: border-box; }
+`;
+
+const ProductGrid = styled.div`
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 16px;
+`;
+
+const ProductCard = styled.div`
+    background: var(--secondary-background);
+    border-radius: 10px;
+    padding: 16px;
+    cursor: pointer;
+    transition: transform 0.15s, box-shadow 0.15s;
+    border: 1px solid transparent;
+    &:hover { transform: translateY(-2px); box-shadow: 0 4px 16px rgba(0,0,0,0.15); border-color: var(--accent); }
+`;
+
+const ProductName = styled.div`
+    font-size: 15px; font-weight: 700; margin-bottom: 4px; color: var(--foreground);
+`;
+
+const VendorLabel = styled.div`
+    font-size: 12px; color: var(--accent); margin-bottom: 8px; display: flex; align-items: center; gap: 4px;
+`;
+
+const PriceDisplay = styled.div`
+    font-size: 18px; font-weight: 700; color: var(--foreground);
+    small { font-size: 12px; font-weight: 400; color: var(--secondary-foreground); }
+`;
+
+const Categories = styled.div`
+    display: flex; flex-wrap: wrap; gap: 4px; margin-top: 8px;
+    span { font-size: 10px; padding: 2px 6px; border-radius: 4px; background: var(--tertiary-background); color: var(--secondary-foreground); }
+`;
+
+const Pagination = styled.div`
+    display: flex; justify-content: center; align-items: center; gap: 8px; margin-top: 24px;
+    button { padding: 6px 14px; border-radius: 6px; border: 1px solid var(--tertiary-foreground);
+        background: var(--secondary-background); color: var(--foreground); cursor: pointer; font-size: 13px;
+        &:disabled { opacity: 0.4; cursor: default; }
+        &:hover:not(:disabled) { background: var(--accent); color: white; border-color: var(--accent); } }
+    span { font-size: 13px; color: var(--secondary-foreground); }
+`;
+
+const LoaderWrap = styled.div`
+    display: flex; align-items: center; justify-content: center; padding: 64px 0;
+`;
+
+const EmptyState = styled.div`
+    text-align: center; padding: 64px 0; color: var(--tertiary-foreground); font-size: 14px;
+`;
+
+const BadgeRow = styled.div`
+    display: flex; gap: 6px; flex-wrap: wrap; margin-top: 6px;
+`;
+
+const Badge = styled.span`
+    font-size: 10px; padding: 2px 6px; border-radius: 4px; background: var(--accent); color: white;
+`;
+
+const CATEGORY_ALL = "all";
+
+const Catalog: React.FC = () => {
+    const client = useClient();
+    const [items, setItems] = useState<CatalogItem[]>([]);
+    const [categories, setCategories] = useState<CategoryInfo[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [query, setQuery] = useState("");
+    const [selectedCat, setSelectedCat] = useState(CATEGORY_ALL);
+    const [minPrice, setMinPrice] = useState("");
+    const [maxPrice, setMaxPrice] = useState("");
+    const [sort, setSort] = useState("newest");
+    const [page, setPage] = useState(1);
+    const [totalPages, setTotalPages] = useState(1);
+    const [total, setTotal] = useState(0);
+
+    const sessionToken = typeof client.session === "string"
+        ? client.session : (client.session as any)?.token ?? "";
+    const headers = { "x-session-token": sessionToken };
+
+    // Fetch categories once
+    useEffect(() => {
+        fetch(`${BACKEND_API_BASE}/catalog/categories`, { headers })
+            .then(r => r.json())
+            .then(res => { if (res?.success) setCategories(res.data); })
+            .catch(() => {});
+    }, []);
+
+    // Fetch products
+    useEffect(() => {
+        setLoading(true);
+        const params = new URLSearchParams();
+        if (query) params.set("q", query);
+        if (selectedCat !== CATEGORY_ALL) params.set("category", selectedCat);
+        if (minPrice) params.set("minPrice", minPrice);
+        if (maxPrice) params.set("maxPrice", maxPrice);
+        if (sort) params.set("sort", sort);
+        params.set("page", String(page));
+        params.set("pageSize", "24");
+
+        fetch(`${BACKEND_API_BASE}/catalog?${params}`, { headers })
+            .then(r => r.json())
+            .then((res: CatalogResponse) => {
+                if (res?.success) {
+                    setItems(res.data.items);
+                    setTotalPages(res.data.pagination.totalPages);
+                    setTotal(res.data.pagination.total);
+                }
+                setLoading(false);
+            })
+            .catch(() => setLoading(false));
+    }, [query, selectedCat, minPrice, maxPrice, sort, page]);
+
+    // Reset page on filter change
+    useEffect(() => { setPage(1); }, [query, selectedCat, minPrice, maxPrice, sort]);
+
+    return (
+        <PageWrap>
+            <h2 style={{ marginBottom: 16, fontSize: 22 }}>Compound Finder</h2>
+            <p style={{ fontSize: 13, color: "var(--secondary-foreground)", marginBottom: 16 }}>
+                Browse peptides and products from all vendors. {total > 0 && `${total} products found.`}
+            </p>
+
+            <SearchRow>
+                <SearchField>
+                    <Search size={16} className="icon" />
+                    <InputBox palette="secondary" value={query}
+                        onChange={e => setQuery(e.currentTarget.value)}
+                        placeholder="Search products…" />
+                    {query && <div className="clear" onClick={() => setQuery("")}><X size={16} /></div>}
+                </SearchField>
+                <SortSelect value={sort} onChange={e => setSort(e.currentTarget.value)}>
+                    <option value="newest">Newest</option>
+                    <option value="name">Name</option>
+                    <option value="price_asc">Lowest Price</option>
+                    <option value="price_desc">Highest Price</option>
+                </SortSelect>
+            </SearchRow>
+
+            <Layout>
+                <Sidebar>
+                    <SidebarTitle>Categories</SidebarTitle>
+                    <CategoryChip active={selectedCat === CATEGORY_ALL} onClick={() => setSelectedCat(CATEGORY_ALL)}>
+                        All {total > 0 && <span>({total})</span>}
+                    </CategoryChip>
+                    {categories.map(c => (
+                        <CategoryChip key={c.category} active={selectedCat === c.category}
+                            onClick={() => setSelectedCat(c.category)}>
+                            {c.category} <span>({c.count})</span>
+                        </CategoryChip>
+                    ))}
+
+                    <div style={{ marginTop: 20 }}>
+                        <SidebarTitle>Price Range</SidebarTitle>
+                        <PriceFilter>
+                            <input type="number" placeholder="Min $"
+                                value={minPrice} onInput={e => setMinPrice((e.target as HTMLInputElement).value)} />
+                            <input type="number" placeholder="Max $"
+                                value={maxPrice} onInput={e => setMaxPrice((e.target as HTMLInputElement).value)} />
+                        </PriceFilter>
+                    </div>
+                </Sidebar>
+
+                <div>
+                    {loading ? (
+                        <LoaderWrap><Preloader type="ring" /></LoaderWrap>
+                    ) : items.length === 0 ? (
+                        <EmptyState>No products found. Try adjusting filters.</EmptyState>
+                    ) : (
+                        <>
+                            <ProductGrid>
+                                {items.map(item => (
+                                    <ProductCard key={item.id}>
+                                        <ProductName>{item.product}</ProductName>
+                                        <VendorLabel>
+                                            {item.vendorName ? <><Store size={14} /> {item.vendorName}</> : "Unknown vendor"}
+                                        </VendorLabel>
+                                        <PriceDisplay>
+                                            ${item.fromPrice}
+                                            {item.toPrice != null && item.toPrice > item.fromPrice && (
+                                                <> — ${item.toPrice}</>
+                                            )}
+                                            <small> / {item.currency}</small>
+                                        </PriceDisplay>
+                                        <Categories>
+                                            {item.categories.map(c => <span key={c}>{c}</span>)}
+                                        </Categories>
+                                    </ProductCard>
+                                ))}
+                            </ProductGrid>
+
+                            {totalPages > 1 && (
+                                <Pagination>
+                                    <button disabled={page <= 1} onClick={() => setPage(p => p - 1)}>‹ Prev</button>
+                                    <span>Page {page} of {totalPages}</span>
+                                    <button disabled={page >= totalPages} onClick={() => setPage(p => p + 1)}>Next ›</button>
+                                </Pagination>
+                            )}
+                        </>
+                    )}
+                </div>
+            </Layout>
+        </PageWrap>
+    );
+};
+
+export default observer(Catalog);

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -13,6 +13,7 @@ import { CategoryButton, InputBox, Preloader } from "@revoltchat/ui";
 import { PageHeader } from "../../components/ui/Header";
 import { useClient } from "../../controllers/client/ClientController";
 import { isTouchscreenDevice } from "../../lib/isTouchscreenDevice";
+import Catalog from "./Catalog";
 import Promos from "./Promos";
 import { BACKEND_API_BASE } from "../directory/types";
 
@@ -271,23 +272,38 @@ const Home: React.FC = () => {
     // dropping the user back on Home.
     const history = useHistory();
     const location = useLocation();
-    const tab: "home" | "promos" =
+    const tab: "home" | "promos" | "catalog" =
         new URLSearchParams(location.search).get("tab") === "promos"
             ? "promos"
+            : new URLSearchParams(location.search).get("tab") === "catalog"
+            ? "catalog"
             : "home";
-    const setTab = (next: "home" | "promos") =>
-        history.replace(next === "promos" ? "/?tab=promos" : "/");
+    const setTab = (next: "home" | "promos" | "catalog") =>
+        history.replace(
+            next === "promos" ? "/?tab=promos" :
+            next === "catalog" ? "/?tab=catalog" :
+            "/"
+        );
+
+    // Promos is only mounted once the user first visits the tab, then stays
+    // mounted (hidden via CSS) for the rest of the session so switching back
+    // and forth doesn't re-create its <img> elements — that unmount/remount
+    // was causing vendor logos to visibly reload every time.
+    const [promosVisited, setPromosVisited] = useState(tab === "promos");
+    const [catalogVisited, setCatalogVisited] = useState(tab === "catalog");
+    useEffect(() => {
+        if (tab === "promos") setPromosVisited(true);
+        if (tab === "catalog") setCatalogVisited(true);
+    }, [tab]);
 
     // On mobile the overlapping panels default to the sidebar; when landing on
-    // the Promos tab (e.g. after a refresh), bring the content panel into view
-    // so the user sees the promos rather than the channel list. Deferred to the
+    // the Promos or Catalog tab (e.g. after a refresh), bring the content panel into view
+    // so the user sees the content rather than the channel list. Deferred to the
     // next frame so the panel container has laid out before we scroll it.
     useEffect(() => {
-        if (!isTouchscreenDevice || tab !== "promos") return;
+        if (!isTouchscreenDevice || (tab !== "promos" && tab !== "catalog")) return;
         const raf = requestAnimationFrame(() => {
             const panels = document.querySelector("#app > div > div > div");
-            // No right panel on home, so the max scroll position lands on the
-            // main (content) panel.
             panels?.scrollTo({ left: panels.scrollWidth, behavior: "auto" });
         });
         return () => cancelAnimationFrame(raf);
@@ -492,55 +508,74 @@ const Home: React.FC = () => {
                                 Promos
                                 <NewChip>New</NewChip>
                             </Tab>
+                            <Tab
+                                active={tab === "catalog"}
+                                onClick={() => setTab("catalog")}>
+                                Compound Finder
+                            </Tab>
                         </TabBar>
                     </PageHeader>
                     <div className={styles.homeScreen}>
-                        {tab === "home" ? (
-                            <>
-                                <SearchWrapper>
-                                    <Search
-                                        size={18}
-                                        className="search-icon"
-                                    />
-                                    <InputBox
-                                        palette="secondary"
-                                        value={query}
-                                        onChange={(e) =>
-                                            setQuery(e.currentTarget.value)
-                                        }
-                                        placeholder="Search communities…"
-                                    />
-                                    {query && (
-                                        <div
-                                            className="clear"
-                                            onClick={() => setQuery("")}>
-                                            <X size={18} />
-                                        </div>
-                                    )}
-                                </SearchWrapper>
-                                {loading ? (
-                                    <LoaderWrapper>
-                                        <Preloader type="ring" />
-                                    </LoaderWrapper>
-                                ) : error ? (
-                                    <NoResults>{error}</NoResults>
-                                ) : (
-                                    <>
-                                        <div className={styles.actions}>
-                                            {filteredServers.map(
-                                                renderServerButton,
-                                            )}
-                                        </div>
-                                        {filteredServers.length === 0 && (
-                                            <NoResults>
-                                                No communities found.
-                                            </NoResults>
-                                        )}
-                                    </>
+                        <div
+                            style={{
+                                display: tab === "home" ? undefined : "none",
+                            }}>
+                            <SearchWrapper>
+                                <Search size={18} className="search-icon" />
+                                <InputBox
+                                    palette="secondary"
+                                    value={query}
+                                    onChange={(e) =>
+                                        setQuery(e.currentTarget.value)
+                                    }
+                                    placeholder="Search communities…"
+                                />
+                                {query && (
+                                    <div
+                                        className="clear"
+                                        onClick={() => setQuery("")}>
+                                        <X size={18} />
+                                    </div>
                                 )}
-                            </>
-                        ) : (
-                            <Promos />
+                            </SearchWrapper>
+                            {loading ? (
+                                <LoaderWrapper>
+                                    <Preloader type="ring" />
+                                </LoaderWrapper>
+                            ) : error ? (
+                                <NoResults>{error}</NoResults>
+                            ) : (
+                                <>
+                                    <div className={styles.actions}>
+                                        {filteredServers.map(
+                                            renderServerButton,
+                                        )}
+                                    </div>
+                                    {filteredServers.length === 0 && (
+                                        <NoResults>
+                                            No communities found.
+                                        </NoResults>
+                                    )}
+                                </>
+                            )}
+                        </div>
+                        {promosVisited && (
+                            <div
+                                style={{
+                                    display:
+                                        tab === "promos" ? undefined : "none",
+                                }}>
+                                <Promos />
+                            </div>
+                        )}
+                        {catalogVisited && (
+                            <div
+                                style={{
+                                    display:
+                                        tab === "catalog" ? undefined : "none",
+                                }}>
+                                <Catalog />
+                            </div>
                         )}
                     </div>
                 </div>

--- a/src/pages/settings/ServerSettings.tsx
+++ b/src/pages/settings/ServerSettings.tsx
@@ -30,6 +30,7 @@ import { Invites } from "./server/Invites";
 import { Members } from "./server/Members";
 import { Overview } from "./server/Overview";
 import { Roles } from "./server/Roles";
+import { CatalogManage } from "./server/CatalogManage";
 import { VendorInfo } from "./server/VendorInfo";
 
 export default observer(() => {
@@ -90,6 +91,12 @@ export default observer(() => {
                         title: <span>Vendor Info</span>,
                     }]
                     : []),
+                ...(server.owner === client.user?._id ? [{
+                    category: <div>Directory</div>,
+                    id: "catalog",
+                    icon: <ListUl size={20} />,
+                    title: <span>Product Catalog</span>,
+                }] : []),
                 {
                     category: (
                         <Text id="app.settings.server_pages.management.title" />
@@ -145,6 +152,9 @@ export default observer(() => {
                     </Route>
                     <Route path="/server/:server/settings/vendor-info">
                         <VendorInfo server={server} />
+                    </Route>
+                    <Route path="/server/:server/settings/catalog">
+                        <CatalogManage server={server} />
                     </Route>
                     <Route>
                         <Overview server={server} />

--- a/src/pages/settings/server/CatalogManage.tsx
+++ b/src/pages/settings/server/CatalogManage.tsx
@@ -1,0 +1,316 @@
+import { observer } from "mobx-react-lite";
+import { Server } from "revolt.js";
+import { useEffect, useState } from "preact/hooks";
+import { useClient } from "../../../controllers/client/ClientController";
+import { BACKEND_API_BASE } from "../../directory/types";
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+interface Variation {
+    dosage?: string | null;
+    price: number;
+    display_quantity?: string | null;
+    unit?: string | null;
+    note?: string | null;
+}
+
+interface CatalogEntry {
+    id: string;
+    serverId?: string | null;
+    product: string;
+    normalized?: string | null;
+    variations: Variation[];
+    currency: string;
+    sku?: string | null;
+    categories: string[];
+    source: string;
+    active: boolean;
+    fromPrice: number;
+    toPrice?: number | null;
+    createdAt: string;
+    updatedAt: string;
+}
+
+interface EntryListResponse {
+    success: boolean;
+    data: { items: CatalogEntry[]; pagination: any };
+}
+
+// ─── Inline styles ───────────────────────────────────────────────────
+
+const S = {
+    wrap: { padding: "24px", maxWidth: "860px" } as const,
+    btn: (variant: "primary" | "danger" | "outline") => ({
+        padding: "8px 18px", borderRadius: "6px", fontSize: "14px", fontWeight: 600,
+        cursor: "pointer",
+        background: variant === "primary" ? "var(--accent)" :
+                    variant === "danger" ? "var(--error)" : "transparent",
+        color: variant === "outline" ? "var(--foreground)" : "white",
+        border: variant === "outline" ? "1px solid var(--tertiary-foreground)" : "none",
+    } as const),
+    input: { width: "100%", padding: "8px 10px", borderRadius: "6px",
+        border: "1px solid var(--tertiary-foreground)", background: "var(--secondary-background)",
+        color: "var(--foreground)", fontSize: "13px", boxSizing: "border-box" as const },
+    label: { fontSize: "11px", fontWeight: 700, textTransform: "uppercase" as const,
+        letterSpacing: "0.06em", color: "var(--secondary-foreground)", marginBottom: "6px" } as const,
+    card: { background: "var(--secondary-background)", borderRadius: "8px", padding: "16px",
+        marginBottom: "12px", border: "1px solid var(--tertiary-foreground)" } as const,
+    row: { display: "flex", gap: "8px", alignItems: "center", marginBottom: "8px", flexWrap: "wrap" as const },
+    grid: { display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(120px, 1fr))", gap: "6px" } as const,
+    status: (ok: boolean) => ({ fontSize: "13px", color: ok ? "var(--success)" : "var(--error)", marginLeft: "12px" } as const),
+    divider: { borderTop: "1px solid var(--tertiary-foreground)", margin: "16px 0" } as const,
+};
+
+// ─── Variation row in the form ───────────────────────────────────────
+
+function VariationRow({ v, idx, onChange, onRemove }: {
+    v: Variation; idx: number;
+    onChange: (idx: number, v: Variation) => void;
+    onRemove: (idx: number) => void;
+}) {
+    return (
+        <div style={{ display: "flex", gap: "6px", alignItems: "center", marginBottom: "6px", flexWrap: "wrap" }}>
+            <input style={{ ...S.input, width: "90px" }} placeholder="Dosage" value={v.dosage ?? ""}
+                onInput={e => onChange(idx, { ...v, dosage: (e.target as HTMLInputElement).value })} />
+            <input style={{ ...S.input, width: "80px" }} type="number" step="0.01" placeholder="Price" value={v.price || ""}
+                onInput={e => onChange(idx, { ...v, price: parseFloat((e.target as HTMLInputElement).value) || 0 })} />
+            <input style={{ ...S.input, width: "70px" }} placeholder="Unit" value={v.unit ?? ""}
+                onInput={e => onChange(idx, { ...v, unit: (e.target as HTMLInputElement).value })} />
+            <button style={S.btn("danger")} onClick={() => onRemove(idx)}>×</button>
+        </div>
+    );
+}
+
+// ─── Edit form for one product ───────────────────────────────────────
+
+function ProductForm({ initial, onSave, onCancel }: {
+    initial?: Partial<CatalogEntry>;
+    onSave: (data: any) => void;
+    onCancel: () => void;
+}) {
+    const [product, setProduct] = useState(initial?.product ?? "");
+    const [sku, setSku] = useState(initial?.sku ?? "");
+    const [currency, setCurrency] = useState(initial?.currency ?? "USD");
+    const [categories, setCategories] = useState((initial?.categories ?? []).join(", "));
+    const [variations, setVariations] = useState<Variation[]>(
+        initial?.variations?.length ? initial.variations : [{ dosage: "", price: 0, unit: "kit" }]
+    );
+
+    function updateVar(idx: number, v: Variation) {
+        setVariations(variations.map((x, i) => i === idx ? v : x));
+    }
+    function removeVar(idx: number) {
+        setVariations(variations.filter((_, i) => i !== idx));
+    }
+    function addVar() {
+        setVariations([...variations, { dosage: "", price: 0, unit: "kit" }]);
+    }
+
+    function handleSave() {
+        const catArr = categories.split(",").map(c => c.trim()).filter(Boolean);
+        const cleanVars = variations.filter(v => v.price > 0 || v.dosage);
+        if (!product || cleanVars.length === 0) return;
+        onSave({
+            product: product.trim(),
+            normalized: product.trim().toLowerCase(),
+            sku: sku.trim() || null,
+            currency,
+            categories: catArr,
+            variations: cleanVars,
+        });
+    }
+
+    return (
+        <div style={S.card}>
+            <div style={S.label}>Product Name</div>
+            <input style={{ ...S.input, marginBottom: 8 }} value={product}
+                onInput={e => setProduct((e.target as HTMLInputElement).value)} placeholder="e.g. Tirzepatide" />
+
+            <div style={S.row}>
+                <div style={{ flex: 1 }}>
+                    <div style={S.label}>SKU (optional)</div>
+                    <input style={S.input} value={sku} onInput={e => setSku((e.target as HTMLInputElement).value)} />
+                </div>
+                <div style={{ width: 100 }}>
+                    <div style={S.label}>Currency</div>
+                    <select style={S.input} value={currency} onChange={e => setCurrency(e.currentTarget.value)}>
+                        <option value="USD">USD</option><option value="CNY">CNY</option>
+                    </select>
+                </div>
+            </div>
+
+            <div style={S.label}>Categories (comma-separated)</div>
+            <input style={{ ...S.input, marginBottom: 12 }} value={categories}
+                onInput={e => setCategories((e.target as HTMLInputElement).value)}
+                placeholder="e.g. Peptides, GLP-1" />
+
+            <div style={S.label}>Variations (dosage + price)</div>
+            {variations.map((v, i) => (
+                <VariationRow key={i} v={v} idx={i} onChange={updateVar} onRemove={removeVar} />
+            ))}
+            <button style={{ ...S.btn("outline"), marginTop: 4 }} onClick={addVar}>+ Add variation</button>
+
+            <div style={S.divider} />
+            <div style={{ display: "flex", gap: 8 }}>
+                <button style={S.btn("primary")} onClick={handleSave}>Save</button>
+                <button style={S.btn("outline")} onClick={onCancel}>Cancel</button>
+            </div>
+        </div>
+    );
+}
+
+// ─── Main component ──────────────────────────────────────────────────
+
+interface Props { server: Server }
+
+export const CatalogManage = observer(({ server }: Props) => {
+    const client = useClient();
+    const [entries, setEntries] = useState<CatalogEntry[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [editingId, setEditingId] = useState<string | null>(null);
+    const [showNewForm, setShowNewForm] = useState(false);
+    const [saveState, setSaveState] = useState<"idle" | "saving" | "ok" | "error">("idle");
+    const [errMsg, setErrMsg] = useState("");
+
+    const sessionToken = typeof client.session === "string"
+        ? client.session : (client.session as any)?.token ?? "";
+    const headers = { "x-session-token": sessionToken, "Content-Type": "application/json" };
+    const sid = server._id;
+
+    function loadEntries() {
+        setLoading(true);
+        fetch(`${BACKEND_API_BASE}/catalog?serverId=${sid}&pageSize=200`, { headers })
+            .then(r => r.json())
+            .then((res: EntryListResponse) => {
+                if (res?.success) setEntries(res.data.items);
+                setLoading(false);
+            })
+            .catch(() => setLoading(false));
+    }
+
+    useEffect(() => { loadEntries(); }, [sid]);
+
+    async function handleCreate(data: any) {
+        setSaveState("saving");
+        try {
+            const r = await fetch(`${BACKEND_API_BASE}/catalog`, {
+                method: "POST", headers,
+                body: JSON.stringify({ ...data, serverId: sid }),
+            });
+            const res = await r.json();
+            if (!r.ok) throw new Error(res?.error || "Failed to create");
+            setShowNewForm(false);
+            setSaveState("ok");
+            setTimeout(() => setSaveState("idle"), 2000);
+            loadEntries();
+        } catch (e: any) {
+            setErrMsg(e.message); setSaveState("error");
+        }
+    }
+
+    async function handleUpdate(id: string, data: any) {
+        setSaveState("saving");
+        try {
+            const r = await fetch(`${BACKEND_API_BASE}/catalog/${id}`, {
+                method: "PUT", headers,
+                body: JSON.stringify(data),
+            });
+            const res = await r.json();
+            if (!r.ok) throw new Error(res?.error || "Failed to update");
+            setEditingId(null);
+            setSaveState("ok");
+            setTimeout(() => setSaveState("idle"), 2000);
+            loadEntries();
+        } catch (e: any) {
+            setErrMsg(e.message); setSaveState("error");
+        }
+    }
+
+    async function handleDelete(id: string) {
+        if (!confirm("Delete this product?")) return;
+        try {
+            const r = await fetch(`${BACKEND_API_BASE}/catalog/${id}`, {
+                method: "DELETE", headers,
+            });
+            if (!r.ok) throw new Error("Failed to delete");
+            loadEntries();
+        } catch (e: any) {
+            setErrMsg(e.message);
+        }
+    }
+
+    const editingEntry = editingId ? entries.find(e => e.id === editingId) : null;
+
+    return (
+        <div style={S.wrap}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
+                <div>
+                    <h3 style={{ margin: 0 }}>Product Catalog</h3>
+                    <p style={{ fontSize: 13, color: "var(--secondary-foreground)", marginTop: 4 }}>
+                        Manage your product catalog. {entries.length} products listed.
+                    </p>
+                </div>
+                <button style={S.btn("primary")} onClick={() => setShowNewForm(true)}>+ Add Product</button>
+            </div>
+
+            {saveState !== "idle" && (
+                <div style={{ marginBottom: 12 }}>
+                    <span style={S.status(saveState === "ok" || saveState === "saving")}>
+                        {saveState === "saving" ? "Saving…" : saveState === "ok" ? "Saved!" : `Error: ${errMsg}`}
+                    </span>
+                </div>
+            )}
+
+            {showNewForm && (
+                <ProductForm onSave={handleCreate} onCancel={() => setShowNewForm(false)} />
+            )}
+
+            {editingId && editingEntry && (
+                <ProductForm
+                    initial={editingEntry}
+                    onSave={data => handleUpdate(editingId, data)}
+                    onCancel={() => setEditingId(null)}
+                />
+            )}
+
+            {loading ? (
+                <p style={{ color: "var(--secondary-foreground)", fontSize: 14 }}>Loading catalog…</p>
+            ) : entries.length === 0 ? (
+                <p style={{ color: "var(--tertiary-foreground)", fontSize: 14 }}>
+                    No products yet. Click "+ Add Product" to get started.
+                </p>
+            ) : (
+                entries.map(entry => (
+                    <div key={entry.id} style={{
+                        ...S.card, display: "flex", justifyContent: "space-between", alignItems: "flex-start"
+                    }}>
+                        <div style={{ flex: 1 }}>
+                            <div style={{ fontSize: 15, fontWeight: 700 }}>{entry.product}</div>
+                            <div style={{ fontSize: 12, color: "var(--accent)", marginTop: 2 }}>
+                                ${entry.fromPrice}{entry.toPrice && entry.toPrice > entry.fromPrice ? ` — $${entry.toPrice}` : ""} / {entry.currency}
+                            </div>
+                            <div style={{ fontSize: 12, color: "var(--secondary-foreground)", marginTop: 2 }}>
+                                {entry.variations?.length ?? 0} variations
+                                {entry.sku ? ` • SKU: ${entry.sku}` : ""}
+                            </div>
+                            {entry.categories?.length > 0 && (
+                                <div style={{ display: "flex", gap: 4, flexWrap: "wrap", marginTop: 6 }}>
+                                    {entry.categories.map(c => (
+                                        <span key={c} style={{
+                                            fontSize: 10, padding: "2px 6px", borderRadius: 4,
+                                            background: "var(--tertiary-background)", color: "var(--secondary-foreground)"
+                                        }}>{c}</span>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                        <div style={{ display: "flex", gap: 6, flexShrink: 0 }}>
+                            <button style={S.btn("outline")} onClick={() => setEditingId(entry.id)}>Edit</button>
+                            <button style={S.btn("danger")} onClick={() => handleDelete(entry.id)}>×</button>
+                        </div>
+                    </div>
+                ))
+            )}
+        </div>
+    );
+});


### PR DESCRIPTION
- New "Compound Finder" tab on home page with Amazon-like product grid, category sidebar, price filter, sort, pagination
- Catalog CRUD pane in server settings (owner only) for managing products
- Wire both to backend /catalog API endpoints

## Please make sure to check the following tasks before opening and submitting a PR

* [ ] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [ ] I have tested my changes locally and they are working as intended
* [ ] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [ ] I have included screenshots to demonstrate my changes
