### PR TITLE
perf(ci): faster docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,8 +77,6 @@ jobs:
               uses: actions/checkout@v2
               with:
                   submodules: "recursive"
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@v1
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v2
             # Branch-aware deploy targets so this file is identical on every

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,11 @@ RUN yarn install --frozen-lockfile
 COPY . .
 COPY .env.build ./.env
 
-RUN yarn build:deps
 # RUN yarn typecheck # lol no
-RUN yarn build:highmem
+# Build submodules once, then vite build directly. build:ci avoids re-running
+# `yarn install` and `build:deps` (which yarn build/build:highmem would repeat).
+RUN NODE_OPTIONS='--max-old-space-size=12288' yarn build:deps
+RUN NODE_OPTIONS='--max-old-space-size=12288' yarn build:ci
 RUN yarn workspaces focus --production --all
 
 FROM node:16-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-buster AS builder
+FROM node:24-bookworm-slim AS builder
 ENV NODE_OPTIONS="--max_old_space_size=12288"
 WORKDIR /usr/src/app
 
@@ -22,7 +22,7 @@ RUN NODE_OPTIONS='--max-old-space-size=12288' yarn build:deps
 RUN NODE_OPTIONS='--max-old-space-size=12288' yarn build:ci
 RUN yarn workspaces focus --production --all
 
-FROM node:16-alpine
+FROM node:24-alpine
 WORKDIR /usr/src/app
 COPY --from=builder /usr/src/app .
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "build:deps": "cd external && cd components && yarn && yarn build:esm && cd .. && cd revolt.js && yarn && yarn build",
         "build": "yarn && rimraf build && node scripts/setup_assets.js --check && yarn build:deps && vite build",
         "build:highmem": "NODE_OPTIONS='--max-old-space-size=12288' yarn build",
+        "build:ci": "rimraf build && node scripts/setup_assets.js --check && vite build",
         "preview": "vite preview",
         "lint": "eslint src/**/*.{js,jsx,ts,tsx}",
         "fmt": "prettier --write 'src/**/*.{js,jsx,ts,tsx}'",


### PR DESCRIPTION
Cut CI docker build time.

- Drop duplicate `yarn install` + `build:deps` (build:highmem reran both). New `build:ci` runs vite build only.
- Remove `setup-qemu` — only linux/amd64 built, native runner needs no emulation.
- Bump base node:16 (EOL) -> node:24. Verified locally with yarn 3.2.0: build:deps + vite build both pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)