### PR TITLE
perf(ci): cache submodule build layer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,5 +8,13 @@ node_modules
 .yarn/cache
 .yarn/install-state.gz
 
+# Nested node_modules + submodule build outputs. Excluded so the `COPY . .`
+# app layer never clobbers the artifacts produced by the earlier build:deps
+# layer (which is cached independently of app-code changes).
+**/node_modules
+external/components/esm
+external/revolt.js/dist
+external/revolt.js/esm
+
 Dockerfile
 .dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,19 @@ COPY external/components/package.json external/components/
 COPY external/revolt.js/package.json external/revolt.js/
 RUN yarn install --frozen-lockfile
 
+# Build the submodules in their own layer keyed only on submodule sources.
+# App-code (src/) changes no longer invalidate this ~3min step — only a real
+# change under external/* does. The built outputs (esm/dist) are kept out of
+# the later `COPY . .` via .dockerignore so they survive that copy.
+COPY external/components external/components
+COPY external/revolt.js external/revolt.js
+RUN NODE_OPTIONS='--max-old-space-size=12288' yarn build:deps
+
 COPY . .
 COPY .env.build ./.env
 
 # RUN yarn typecheck # lol no
-# Build submodules once, then vite build directly. build:ci avoids re-running
-# `yarn install` and `build:deps` (which yarn build/build:highmem would repeat).
-RUN NODE_OPTIONS='--max-old-space-size=12288' yarn build:deps
+# vite build only — build:ci skips the redundant yarn install + build:deps.
 RUN NODE_OPTIONS='--max-old-space-size=12288' yarn build:ci
 RUN yarn workspaces focus --production --all
 


### PR DESCRIPTION
Split build:deps into its own docker layer so app-code changes don't rebuild submodules (~3min saved on typical deploys). See commit for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)