### PR TITLE
feat(analytics): wire PostHog client analytics (prod)

### DIFF
--- a/.env.build
+++ b/.env.build
@@ -1,2 +1,4 @@
 VITE_API_URL=https://peptide.chat/api
 VITE_THEMES_URL=https://themes.revolt.chat
+VITE_POSTHOG_KEY=phc_CAMrLp2uTNDB9CpU3dfnDJF7y2oUZAazF9pxs8hd5ksp
+VITE_POSTHOG_HOST=https://us.i.posthog.com

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "fs-extra": "^10.0.0",
         "klaw": "^3.0.0",
         "lottie-react": "^2.4.0",
+        "posthog-js": "^1.402.3",
         "sirv-cli": "^1.0.14",
         "vite": "^3.0.5"
     },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { render } from "preact";
 
 import "../external/lang/Languages.patch";
 import { App } from "./pages/app";
+import "./posthog";
 import "./updateWorker";
 import './sentry';
  

--- a/src/posthog.ts
+++ b/src/posthog.ts
@@ -1,0 +1,16 @@
+import posthog from "posthog-js";
+
+const key = import.meta.env.VITE_POSTHOG_KEY;
+
+// Only initialise when a project key is configured (e.g. omitted in local dev).
+if (key) {
+    posthog.init(key as string, {
+        api_host:
+            (import.meta.env.VITE_POSTHOG_HOST as string) ||
+            "https://us.i.posthog.com",
+        person_profiles: "identified_only",
+        capture_pageview: true,
+    });
+}
+
+export default posthog;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2252,6 +2252,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@posthog/core@npm:^1.42.1":
+  version: 1.42.1
+  resolution: "@posthog/core@npm:1.42.1"
+  dependencies:
+    "@posthog/types": ^1.395.0
+  checksum: e9fbeb0f7978feaf379559ed2b8300a614726b889be8e6e7b69ab9607d8143babec3712ef28ef7d1a08f2d120c3be7b6d501d2453889397140ee668aef9e0e02
+  languageName: node
+  linkType: hard
+
+"@posthog/types@npm:^1.395.0":
+  version: 1.395.0
+  resolution: "@posthog/types@npm:1.395.0"
+  checksum: 7e4c41bbd74f7fdf42a52131f043bf2cbebd7b3d97538b32e79f2a9cc1f016ab4802bce9257c891ffa2277ad0659319b09f510f7b9d245dc059284beba1fb346
+  languageName: node
+  linkType: hard
+
 "@preact/preset-vite@npm:^2.0.0":
   version: 2.1.0
   resolution: "@preact/preset-vite@npm:2.1.0"
@@ -2985,6 +3001,13 @@ __metadata:
   version: 2.0.2
   resolution: "@types/trusted-types@npm:2.0.2"
   checksum: 3371eef5f1c50e1c3c07a127c1207b262ba65b83dd167a1c460fc1b135a3fb0c97b9f508efebd383f239cc5dd5b7169093686a692a501fde9c3f7208657d9b0d
+  languageName: node
+  linkType: hard
+
+"@types/trusted-types@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@types/trusted-types@npm:2.0.7"
+  checksum: 8e4202766a65877efcf5d5a41b7dd458480b36195e580a3b1085ad21e948bc417d55d6f8af1fd2a7ad008015d4117d5fdfe432731157da3c68678487174e4ba3
   languageName: node
   linkType: hard
 
@@ -3913,6 +3936,7 @@ __metadata:
     mediasoup-client: "npm:@insertish/mediasoup-client@3.6.36-esnext"
     mobx: ^6.6.0
     mobx-react-lite: 3.4.0
+    posthog-js: ^1.402.3
     preact: ^10.5.14
     preact-context-menu: 0.4.1
     preact-i18n: ^2.4.0-preactx
@@ -4139,6 +4163,13 @@ __metadata:
   version: 3.21.1
   resolution: "core-js@npm:3.21.1"
   checksum: d68eddd831340ad5b24ac29c72fda022a43b17f194c4278b6b875a843283d316502cb4abd07f28631d6ebc4387f66aa06e2b1b3c8fd7e08096a751b5c63f6889
+  languageName: node
+  linkType: hard
+
+"core-js@npm:^3.49.0":
+  version: 3.49.0
+  resolution: "core-js@npm:3.49.0"
+  checksum: 0e2c7ce0d6639ac6b0c040c6e82d415e84f94a542fb6523388d204a1c5c2e503870aa64de180115d56a7bc7c780e43b5eab4b925a6f821a9d27f4b92d191713d
   languageName: node
   linkType: hard
 
@@ -4378,6 +4409,18 @@ __metadata:
   dependencies:
     esutils: ^2.0.2
   checksum: fd7673ca77fe26cd5cba38d816bc72d641f500f1f9b25b83e8ce28827fe2da7ad583a8da26ab6af85f834138cf8dae9f69b0cd6ab925f52ddab1754db44d99ce
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.3.2":
+  version: 3.4.12
+  resolution: "dompurify@npm:3.4.12"
+  dependencies:
+    "@types/trusted-types": ^2.0.7
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 477e944e669bac9247c9ebfa55c7ea5c73f3cc6cd6b21ee72e306000e3e53d308e7bdaac89e655a0e2661de2ffbdd877e6a92537d07ba1d70c6c441fcef8c65c
   languageName: node
   linkType: hard
 
@@ -5183,6 +5226,13 @@ __metadata:
   dependencies:
     reusify: ^1.0.4
   checksum: 486db511686b5ab28b1d87170f05c3fa6c8d769cde6861ed34cf3756cdf356950ba9c7dde0bc976ad4308b85aa9ef6214c685887f9f724be72c054a7becb642a
+  languageName: node
+  linkType: hard
+
+"fflate@npm:^0.4.8":
+  version: 0.4.8
+  resolution: "fflate@npm:0.4.8"
+  checksum: 29d8cbe44d5e7f53e7f5a160ac7f9cc025480c7b3bfd85c5f898cbe20dfa2dad4732daa534982664bf30b35896a90af44ea33ede5d94c5ffd1b8b0c0a0a56ca2
   languageName: node
   linkType: hard
 
@@ -7783,6 +7833,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"posthog-js@npm:^1.402.3":
+  version: 1.402.3
+  resolution: "posthog-js@npm:1.402.3"
+  dependencies:
+    "@posthog/core": ^1.42.1
+    "@posthog/types": ^1.395.0
+    core-js: ^3.49.0
+    dompurify: ^3.3.2
+    fflate: ^0.4.8
+    preact: ^10.29.3
+    query-selector-shadow-dom: ^1.0.1
+    web-vitals: ^5.3.0
+  checksum: 43b012c2d58c37cb0b3c06597102fb171dbd3f0f1c5e596eba498e86fabafb33bd2cecf0db9d77172f3347433211004020deafc008d1e969d4e9ea422c4ddaf8
+  languageName: node
+  linkType: hard
+
 "preact-context-menu@npm:0.4.1":
   version: 0.4.1
   resolution: "preact-context-menu@npm:0.4.1"
@@ -7817,6 +7883,18 @@ __metadata:
   version: 10.5.14
   resolution: "preact@npm:10.5.14"
   checksum: d936f83a2afad13aa5870812d7fa8fec111d4a1bb6b0bea6485f2656a062bcc01717398d8184c4bc589cba455f3b2def8e43ba23db846b208d9823e3804658ad
+  languageName: node
+  linkType: hard
+
+"preact@npm:^10.29.3":
+  version: 10.29.7
+  resolution: "preact@npm:10.29.7"
+  peerDependencies:
+    preact-render-to-string: ">=5"
+  peerDependenciesMeta:
+    preact-render-to-string:
+      optional: true
+  checksum: b972cfff63baaecca86440abb7f6fd27cb73b108efa8f055244b449cbf611b5105a3a0335fc57f05c51b4b5712e8a3f1b2fa61e7451f69d6bbbb2f6ed353ec92
   languageName: node
   linkType: hard
 
@@ -7928,6 +8006,13 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 4102e9f416d86808728b93dca4e90cab0b2d3eca2bfe501a26ca62237062ded2121711cfc4edf64832c63e04d34956e26c2e7088023949f9328bbaa56004777d
+  languageName: node
+  linkType: hard
+
+"query-selector-shadow-dom@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "query-selector-shadow-dom@npm:1.0.1"
+  checksum: 8ab1cdd5e1927b583503b590165d66770fb91c87ac28b50a43596b755db3792c0e506250f46d0af97f0064a5cc12a1de449fd5c2cfcadf18b0880a4d8aecebbd
   languageName: node
   linkType: hard
 
@@ -9834,6 +9919,13 @@ __metadata:
   version: 2.0.1
   resolution: "web-namespaces@npm:2.0.1"
   checksum: b6d9f02f1a43d0ef0848a812d89c83801d5bbad57d8bb61f02eb6d7eb794c3736f6cc2e1191664bb26136594c8218ac609f4069722c6f56d9fc2d808fa9271c6
+  languageName: node
+  linkType: hard
+
+"web-vitals@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "web-vitals@npm:5.3.0"
+  checksum: 0140e84c1ecf42e4f3097f451c3d8d97141b1eb3d9756efa80c1d9c0cc1b087d451280603e5bc12d83af078b91979e685823a9c567db0c13bad30600b42eb24f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Promotes PostHog analytics to production, mirroring the change already on `stage`.

## What
- Add `posthog-js` and initialise it in `src/posthog.ts` from build-time `VITE_POSTHOG_KEY` / `VITE_POSTHOG_HOST`. Init is guarded on the key being present, so a local dev build with no key is a no-op.
- Import `./posthog` in `src/main.tsx`.
- Bake the public `phc_` project key + US host into `.env.build`.

## Env-lane safety
`.env.build` **keeps master's prod API URL** (`https://peptide.chat/api`) — only the two PostHog lines were added. The stage↔master API-URL divergence is preserved; this was a hand-resolved cherry-pick, not a branch merge.

## Notes
- `phc_` project key is a public, write-only ingestion key — safe to ship in the client bundle and commit. Optionally lock it to allowed domains in PostHog project settings.
- Host defaults to US cloud (`https://us.i.posthog.com`).
- Verified locally on `stage`: Vite inlines both vars into `import.meta.env`, `posthog-js` resolves, and `posthog.init` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)