### PR TITLE
feat(mobile): app-install banner + deep-link association (prod)

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,15 @@
+{
+    "applinks": {
+        "details": [
+            {
+                "appIDs": ["R8387T64JW.chat.zeko.app"],
+                "components": [
+                    {
+                        "/": "*",
+                        "comment": "Open all app.peptide.chat paths in the Zeko iOS app when installed."
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -3,19 +3,9 @@
         "relation": ["delegate_permission/common.handle_all_urls"],
         "target": {
             "namespace": "android_app",
-            "package_name": "chat.revolt.app.twa",
+            "package_name": "com.zekochat",
             "sha256_cert_fingerprints": [
-                "6E:62:C1:BF:5A:2D:11:31:A3:22:91:8D:22:2B:2C:49:D3:70:F3:A1:45:DF:11:6A:97:DC:4C:A9:3B:C3:AA:FB"
-            ]
-        }
-    },
-    {
-        "relation": ["delegate_permission/common.handle_all_urls"],
-        "target": {
-            "namespace": "android_app",
-            "package_name": "chat.revolt.app.twa",
-            "sha256_cert_fingerprints": [
-                "2B:C7:89:87:BD:62:88:38:7B:C0:D7:5F:D1:10:F4:91:D5:24:A6:B3:25:3A:75:C2:3A:91:07:1B:63:C0:98:67"
+                "C3:EB:F5:EF:04:56:B8:99:49:26:CE:A0:28:0C:50:EE:97:7D:21:5B:F6:B6:8B:E2:2B:1A:B0:96:4F:26:58:43"
             ]
         }
     }

--- a/src/components/app/AppInstallBanner.tsx
+++ b/src/components/app/AppInstallBanner.tsx
@@ -131,12 +131,14 @@ export default function AppInstallBanner() {
     return (
         <Banner>
             <div className="text">{"Get the app for a better experience"}</div>
+            {/* Opening the store does NOT dismiss — a user who bounces off the
+                store without installing should keep seeing the nudge. Only the
+                explicit × below persists a dismissal. */}
             <a
                 className="open"
                 href={url}
                 target="_blank"
-                rel="noreferrer"
-                onClick={dismiss}>
+                rel="noreferrer">
                 {"Open app"}
             </a>
             <div className="dismiss" onClick={dismiss} aria-label="Dismiss">

--- a/src/components/app/AppInstallBanner.tsx
+++ b/src/components/app/AppInstallBanner.tsx
@@ -143,7 +143,7 @@ export default function AppInstallBanner() {
     return (
         <Banner>
             <div className="text">
-                {"⚡Faster, with reply notifications — Get the app"}
+                {"⚡Faster, with reply notifications"}
             </div>
             {/* Opening the store does NOT dismiss — a user who bounces off the
                 store without installing should keep seeing the nudge. Only the

--- a/src/components/app/AppInstallBanner.tsx
+++ b/src/components/app/AppInstallBanner.tsx
@@ -130,7 +130,9 @@ export default function AppInstallBanner() {
 
     return (
         <Banner>
-            <div className="text">{"Get the app for a better experience"}</div>
+            <div className="text">
+                {"⚡Faster, with reply notifications — Get the app"}
+            </div>
             {/* Opening the store does NOT dismiss — a user who bounces off the
                 store without installing should keep seeing the nudge. Only the
                 explicit × below persists a dismissal. */}
@@ -139,7 +141,7 @@ export default function AppInstallBanner() {
                 href={url}
                 target="_blank"
                 rel="noreferrer">
-                {"Open app"}
+                {"Open App"}
             </a>
             <div className="dismiss" onClick={dismiss} aria-label="Dismiss">
                 {"×"}

--- a/src/components/app/AppInstallBanner.tsx
+++ b/src/components/app/AppInstallBanner.tsx
@@ -24,6 +24,18 @@ const IOS_URL = "https://apps.apple.com/app/id6756353165";
 const ANDROID_URL =
     "https://play.google.com/store/apps/details?id=com.zekochat";
 
+/**
+ * iPadOS 13+ Safari reports a desktop (macOS) user-agent, so react-device-detect
+ * flags it as macOS and `isIOS` is false. Detect it via the Mac UA + a touch
+ * screen (real Macs report 0 touch points; iPads report several). Treated as iOS.
+ */
+const isIpadOS =
+    typeof navigator !== "undefined" &&
+    navigator.maxTouchPoints > 1 &&
+    /Macintosh/.test(navigator.userAgent);
+
+const isApple = isIOS || isIpadOS;
+
 const Banner = styled.div`
     position: fixed;
     top: 0;
@@ -82,7 +94,7 @@ const Banner = styled.div`
  */
 function shouldShow(): boolean {
     if (window.isNative) return false;
-    if (!isIOS && !isAndroid) return false;
+    if (!isApple && !isAndroid) return false;
 
     try {
         const raw = localStorage.getItem(DISMISS_KEY);
@@ -117,7 +129,7 @@ export default function AppInstallBanner() {
 
     if (!visible) return null;
 
-    const url = isIOS ? IOS_URL : ANDROID_URL;
+    const url = isApple ? IOS_URL : ANDROID_URL;
 
     const dismiss = () => {
         try {

--- a/src/components/app/AppInstallBanner.tsx
+++ b/src/components/app/AppInstallBanner.tsx
@@ -1,0 +1,147 @@
+import { isAndroid, isIOS } from "react-device-detect";
+import styled from "styled-components/macro";
+
+import { useEffect, useState } from "preact/hooks";
+
+/**
+ * Height of the banner. Kept in sync with the `--app-banner-height` CSS
+ * variable so the rest of the app can reserve space for it (see
+ * `src/styles/_page.scss` and `src/context/Theme.tsx`).
+ */
+const BANNER_HEIGHT = 44;
+
+/**
+ * How long a dismissal is respected before the banner shows again.
+ */
+const DISMISS_DURATION = 24 * 60 * 60 * 1000; // 1 day
+
+const DISMISS_KEY = "appInstallBannerDismissedAt";
+
+/**
+ * Store links (locale-neutral; the stores resolve the visitor's storefront).
+ */
+const IOS_URL = "https://apps.apple.com/app/id6756353165";
+const ANDROID_URL =
+    "https://play.google.com/store/apps/details?id=com.zekochat";
+
+const Banner = styled.div`
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 9000;
+
+    height: ${BANNER_HEIGHT}px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0 12px;
+
+    font-size: 13px;
+    user-select: none;
+    color: var(--foreground);
+    background: var(--secondary-background);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+
+    .text {
+        flex-grow: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .open {
+        flex-shrink: 0;
+        padding: 6px 12px;
+        border-radius: var(--border-radius);
+        background: var(--accent);
+        color: var(--accent-contrast, #fff);
+        font-weight: 600;
+        cursor: pointer;
+    }
+
+    .dismiss {
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        cursor: pointer;
+        color: var(--tertiary-foreground);
+        font-size: 20px;
+        line-height: 1;
+    }
+`;
+
+/**
+ * Decide whether the install banner should be shown on this load.
+ * Only mobile-web (iOS / Android browser, not the desktop-native build),
+ * and not dismissed within the last day.
+ */
+function shouldShow(): boolean {
+    if (window.isNative) return false;
+    if (!isIOS && !isAndroid) return false;
+
+    try {
+        const raw = localStorage.getItem(DISMISS_KEY);
+        if (raw) {
+            const ts = parseInt(raw, 10);
+            if (!Number.isNaN(ts) && Date.now() - ts < DISMISS_DURATION) {
+                return false;
+            }
+        }
+    } catch (e) {
+        // localStorage may be unavailable (private mode); default to showing.
+    }
+
+    return true;
+}
+
+/**
+ * Dismissible banner nudging mobile-web users towards the native apps.
+ */
+export default function AppInstallBanner() {
+    const [visible, setVisible] = useState(shouldShow);
+
+    // Reserve / release vertical space for the fixed banner.
+    useEffect(() => {
+        const root = document.documentElement.style;
+        root.setProperty(
+            "--app-banner-height",
+            visible ? `${BANNER_HEIGHT}px` : "0px",
+        );
+        return () => root.setProperty("--app-banner-height", "0px");
+    }, [visible]);
+
+    if (!visible) return null;
+
+    const url = isIOS ? IOS_URL : ANDROID_URL;
+
+    const dismiss = () => {
+        try {
+            localStorage.setItem(DISMISS_KEY, Date.now().toString());
+        } catch (e) {
+            // ignore write failures
+        }
+        setVisible(false);
+    };
+
+    return (
+        <Banner>
+            <div className="text">{"Get the app for a better experience"}</div>
+            <a
+                className="open"
+                href={url}
+                target="_blank"
+                rel="noreferrer"
+                onClick={dismiss}>
+                {"Open app"}
+            </a>
+            <div className="dismiss" onClick={dismiss} aria-label="Dismiss">
+                {"×"}
+            </div>
+        </Banner>
+    );
+}

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -409,7 +409,10 @@ export default observer(() => {
 
     useEffect(() => {
         const resize = () =>
-            root.setProperty("--app-height", `${window.innerHeight}px`);
+            root.setProperty(
+                "--app-height",
+                `calc(${window.innerHeight}px - var(--app-banner-height, 0px))`,
+            );
         resize();
 
         window.addEventListener("resize", resize);

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -8,6 +8,7 @@ import ErrorBoundary from "../lib/ErrorBoundary";
 
 import Context from "../context";
 
+import AppInstallBanner from "../components/app/AppInstallBanner";
 import { CheckAuth } from "../controllers/client/jsx/CheckAuth";
 import Invite from "./invite/Invite";
 
@@ -26,6 +27,7 @@ export function App() {
         <ErrorBoundary section="client">
             <Context>
                 <Masks />
+                <AppInstallBanner />
                 <Switch>
                     <Route path="/login/verify/:token">
                         <LoadSuspense>

--- a/src/styles/_page.scss
+++ b/src/styles/_page.scss
@@ -38,8 +38,9 @@ body {
 
 #app {
     position: fixed;
-    top: 0;
+    /* Reserve space for the app-install banner (0 when hidden). */
+    top: var(--app-banner-height, 0px);
     left: 0;
     width: 100%;
-    height: 100%;
+    height: calc(100% - var(--app-banner-height, 0px));
 }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -22,6 +22,9 @@
      * Layout
      */
     --app-height: 100vh;
+    /* Height reserved for the mobile-web app-install banner; 0 when hidden.
+       Set by src/components/app/AppInstallBanner.tsx. */
+    --app-banner-height: 0px;
     --scrollbar-thickness: var(--space-1);
     --scrollbar-thickness-ff: thin;
     --border-radius: var(--radius-md);


### PR DESCRIPTION
Cherry-picks the mobile-web app-install banner + deep-link association files onto `master` for production. **Do not merge yet** — hold until the native iOS/Android apps are live with some adoption.

### Included (5 commits, cherry-picked from stage)
- `feat(mobile)` app-install banner for mobile web
- `fix(mobile)` don't dismiss on "Open App"
- `copy(mobile)` banner text ("⚡Faster, with reply notifications — Get the app")
- `feat(mobile)` iPadOS detection (Mac UA + touch points)
- `feat(deeplink)` `.well-known/apple-app-site-association` + `assetlinks.json` for the Zeko apps

### Notes
- Banner works **without** universal links today (buttons go to the store). The `.well-known` files are inert until the native apps ship their entitlements.
- Uses the full "Get the app" copy — the interim stage build drops that phrase; this restores it for the adoption-phase launch.
- Excludes stage-only changes (stage API URL, catalog WIP) — those must not reach prod.
- Prod ingress host `app.peptide.chat` is already merged in the admin repo; merging this delivers the `.well-known` files to the prod image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)